### PR TITLE
ci(deploy): Add APP_URL environment variable to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             DIRECT_URL=${{ secrets.DIRECT_URL }}
             CORS_ORIGINS=${{ vars.CORS_ORIGINS }}
+            APP_URL=${{ vars.APP_URL }}
             API_URL=${{ secrets.API_URL }}
             SUPABASE_URL=${{ secrets.SUPABASE_URL }}
             SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}


### PR DESCRIPTION
Added APP_URL environment variable to the Cloud Run deployment configuration. This allows the application to reference its own URL for various purposes.