### PR TITLE
fix: set cookie secure flag based on environment

### DIFF
--- a/apps/server/src/modules/auth/auth.controller.ts
+++ b/apps/server/src/modules/auth/auth.controller.ts
@@ -85,6 +85,7 @@ export class AuthController {
   @Get('callback/google')
   @HttpCode(HttpStatus.OK)
   async callbackGoogle(@Req() req: any, @Res() res: any) {
+    const isProd = this.configService.get('NODE_ENV') === 'production';
     const code = req.query.code as string;
     if (!code) {
       return res.status(400).send('missing code');
@@ -104,7 +105,7 @@ export class AuthController {
       httpOnly: true,
       path: '/',
       sameSite: 'lax',
-      secure: false,
+      secure: isProd,
       maxAge: expires_in * 1000,
     });
 
@@ -113,7 +114,7 @@ export class AuthController {
       httpOnly: true,
       path: '/',
       sameSite: 'lax',
-      secure: false,
+      secure: isProd,
       maxAge: expires_in * 1000,
     });
 

--- a/apps/server/src/modules/auth/supabase-auth.guard.module.ts
+++ b/apps/server/src/modules/auth/supabase-auth.guard.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
 import { PrismaAdapterModule } from '$adapters';
 import { AuthRepository } from '$modules/auth/repositories/auth.repository';
 import { SupabaseAuthGuard } from './supabase-auth.guard';
 
 @Module({
-  exports: [AuthRepository, SupabaseAuthGuard],
+  exports: [AuthRepository, ConfigModule, SupabaseAuthGuard],
   imports: [PrismaAdapterModule],
-  providers: [AuthRepository, SupabaseAuthGuard],
+  providers: [AuthRepository, ConfigModule, SupabaseAuthGuard],
 })
 export class SupabaseAuthGuardModule {}

--- a/apps/server/src/modules/auth/supabase-auth.guard.spec.ts
+++ b/apps/server/src/modules/auth/supabase-auth.guard.spec.ts
@@ -1,4 +1,5 @@
 import { ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import * as supabaseFactory from '$adapters';
@@ -26,11 +27,19 @@ describe('SupabaseAuthGuard', () => {
     updateUser: jest.fn(),
   };
 
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue('development'),
+  };
+
   beforeEach(async () => {
     // console.logの出力を抑制
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SupabaseAuthGuard, { provide: AuthRepository, useValue: mockAuthRepository }],
+      providers: [
+        SupabaseAuthGuard,
+        { provide: AuthRepository, useValue: mockAuthRepository },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
     }).compile();
 
     guard = module.get<SupabaseAuthGuard>(SupabaseAuthGuard);

--- a/apps/server/src/shared/adapters/supabase/supabase.factory.ts
+++ b/apps/server/src/shared/adapters/supabase/supabase.factory.ts
@@ -1,6 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
 export const createServerSupabase = (req: any, res: any) => {
+  // 環境変数または NODE_ENV から secure フラグを決定
+  const isProd = process.env.NODE_ENV === 'production';
+
   return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
     auth: {
       flowType: 'pkce',
@@ -26,7 +29,7 @@ export const createServerSupabase = (req: any, res: any) => {
             httpOnly: true,
             path: '/',
             sameSite: 'lax',
-            secure: false, // ← 本番は true
+            secure: isProd, // ← 本番は true
           });
         },
         removeItem: (key) => {

--- a/apps/server/src/shared/adapters/supabase/supabase.storage.adapter.ts
+++ b/apps/server/src/shared/adapters/supabase/supabase.storage.adapter.ts
@@ -1,5 +1,5 @@
 import { ERROR_CODE } from '@monorepo/error-code';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
 
@@ -7,7 +7,6 @@ import { BusinessLogicError } from '$exceptions';
 
 @Injectable()
 export class SupabaseStorageAdapter {
-  private readonly logger = new Logger(SupabaseStorageAdapter.name);
   private readonly supabase: SupabaseClient;
 
   constructor(private readonly configService: ConfigService) {

--- a/apps/server/turbo.json
+++ b/apps/server/turbo.json
@@ -4,10 +4,10 @@
   "tasks": {
     "build": {
       "outputs": ["dist/**"],
-      "env": ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+      "env": ["NODE_ENV", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
     },
     "lint": {
-      "env": ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+      "env": ["NODE_ENV", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
     }
   }
 }


### PR DESCRIPTION
- 本番環境ではCookieのsecureフラグをtrueに設定
- SupabaseAuthGuardにConfigServiceを追加してNODE_ENVを参照
- PKCE code verifierが開発環境で正しく保存/送信されるように修正
- テストにConfigServiceのモックを追加