### PR TITLE
feat: 記事一覧と記事詳細のレスポンシブ対応

### DIFF
--- a/apps/client/src/app/article/[id]/_components/page-content.tsx
+++ b/apps/client/src/app/article/[id]/_components/page-content.tsx
@@ -6,9 +6,9 @@ interface PageContentProps {
 
 export function PageContent({ page }: PageContentProps) {
   return (
-    <article className="max-w-4xl pl-12">
-      <h1 className="text-4xl font-bold mb-8 text-gray-900">{page.title}</h1>
-      <div className="prose prose-lg max-w-none" dangerouslySetInnerHTML={{ __html: page.html }} />
+    <article className="max-w-4xl lg:pl-12">
+      <h1 className="text-3xl md:text-4xl font-bold mb-6 md:mb-8 text-gray-900">{page.title}</h1>
+      <div className="prose prose-base md:prose-lg max-w-none" dangerouslySetInnerHTML={{ __html: page.html }} />
     </article>
   );
 }

--- a/apps/client/src/app/article/[id]/_components/page-layout.tsx
+++ b/apps/client/src/app/article/[id]/_components/page-layout.tsx
@@ -1,3 +1,6 @@
+'use client';
+import { useState } from 'react';
+
 import { PageDto, PageItem } from '$domains/article-page';
 import { PageContent } from './page-content';
 import { PageNavigation } from './page-navigation';
@@ -15,20 +18,33 @@ interface PageLayoutProps {
 }
 
 export function PageLayout({ articleId, pageId, pages, page, toc }: PageLayoutProps) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
   return (
     <div className="flex min-h-screen">
+      {/* ハンバーガーメニューボタン（モバイル・タブレットのみ） */}
+      <button
+        onClick={() => setIsSidebarOpen(true)}
+        className="fixed top-20 left-4 z-50 p-2 rounded-lg bg-white shadow-lg border border-gray-200 lg:hidden hover:bg-gray-50 transition-colors"
+        aria-label="メニューを開く"
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+
       {/* 左サイドバー: ページ一覧 */}
-      <PageSidebar articleId={articleId} pages={pages} currentPageId={pageId} />
+      <PageSidebar
+        articleId={articleId}
+        pages={pages}
+        currentPageId={pageId}
+        isOpen={isSidebarOpen}
+        onClose={() => setIsSidebarOpen(false)}
+      />
 
       {/* メインコンテンツ */}
-      <main
-        className="flex-1 overflow-y-auto"
-        style={{
-          marginLeft: '256px', // 左サイドバーの幅 (w-64 = 256px)
-          marginRight: '240px', // 右サイドバーの幅 (w-60 = 240px)
-        }}
-      >
-        <div className="max-w-5xl mx-auto px-8 py-12">
+      <main className="flex-1 overflow-y-auto lg:ml-64 lg:mr-60">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
           <PageContent page={page} />
 
           <PageNavigation articleId={articleId} pages={pages} currentPageId={pageId} />

--- a/apps/client/src/app/article/[id]/_components/page-navigation.tsx
+++ b/apps/client/src/app/article/[id]/_components/page-navigation.tsx
@@ -18,7 +18,7 @@ export function PageNavigation({ articleId, pages, currentPageId }: PageNavigati
   }
 
   return (
-    <div className="flex justify-between items-center border-t border-gray-200 pt-6 mt-12">
+    <div className="flex flex-col md:flex-row justify-between items-stretch md:items-center gap-4 border-t border-gray-200 pt-6 mt-8 md:mt-12">
       <div className="flex-1">
         {prevPage && (
           <Link
@@ -26,7 +26,7 @@ export function PageNavigation({ articleId, pages, currentPageId }: PageNavigati
             className="group inline-flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
           >
             <svg
-              className="w-5 h-5 mr-2 group-hover:-translate-x-1 transition-transform"
+              className="w-5 h-5 mr-2 flex-shrink-0 group-hover:-translate-x-1 transition-transform"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -40,18 +40,18 @@ export function PageNavigation({ articleId, pages, currentPageId }: PageNavigati
           </Link>
         )}
       </div>
-      <div className="flex-1 flex justify-end">
+      <div className="flex-1 flex justify-start md:justify-end">
         {nextPage && (
           <Link
             href={`/article/${articleId}/${nextPage.id}`}
-            className="group inline-flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors text-right"
+            className="group inline-flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors md:text-right"
           >
             <div>
               <div className="text-xs text-gray-500 mb-1">次のページ</div>
               <div className="font-medium">{nextPage.title}</div>
             </div>
             <svg
-              className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform"
+              className="w-5 h-5 ml-2 flex-shrink-0 group-hover:translate-x-1 transition-transform"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/apps/client/src/app/article/[id]/_components/page-sidebar.tsx
+++ b/apps/client/src/app/article/[id]/_components/page-sidebar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import Link from 'next/link';
 
 import { PageItem } from '$domains/article-page';
@@ -6,43 +7,64 @@ interface PageSidebarProps {
   articleId: string;
   pages: PageItem[];
   currentPageId: string;
+  isOpen: boolean;
+  onClose: () => void;
 }
 
-export function PageSidebar({ articleId, pages, currentPageId }: PageSidebarProps) {
+export function PageSidebar({ articleId, pages, currentPageId, isOpen, onClose }: PageSidebarProps) {
   return (
-    <aside
-      className="w-64 border-r border-gray-200 bg-gray-50 p-6 overflow-y-auto"
-      style={{
-        position: 'fixed',
-        top: '64px',
-        left: 0,
-        height: 'calc(100vh - 64px)',
-      }}
-    >
-      <nav>
-        <h2 className="text-sm font-semibold text-gray-900 mb-4">目次</h2>
-        <ul className="space-y-2">
-          {pages.map((page) => {
-            const isActive = page.id === currentPageId;
-            const indentClass = page.level === 2 ? 'ml-4' : '';
+    <>
+      {/* オーバーレイ（モバイル・タブレットのみ） */}
+      {isOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden" onClick={onClose} aria-hidden="true" />
+      )}
 
-            return (
-              <li key={page.id} className={indentClass}>
-                <Link
-                  href={`/article/${articleId}/${page.id}`}
-                  className={`block text-sm py-1 px-2 rounded transition-colors ${
-                    isActive
-                      ? 'bg-blue-100 text-blue-700 font-medium'
-                      : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
-                  }`}
-                >
-                  {page.title}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
-    </aside>
+      {/* サイドバー */}
+      <aside
+        className={`
+          fixed top-16 left-0 h-[calc(100vh-4rem)] w-64
+          border-r border-gray-200 bg-gray-50 p-6 overflow-y-auto
+          z-50 transition-transform duration-300 ease-in-out
+          ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
+        `}
+      >
+        <nav>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-900">目次</h2>
+            <button
+              onClick={onClose}
+              className="lg:hidden p-1 rounded hover:bg-gray-200 transition-colors"
+              aria-label="閉じる"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <ul className="space-y-2">
+            {pages.map((page) => {
+              const isActive = page.id === currentPageId;
+              const indentClass = page.level === 2 ? 'ml-4' : '';
+
+              return (
+                <li key={page.id} className={indentClass}>
+                  <Link
+                    href={`/article/${articleId}/${page.id}`}
+                    className={`block text-sm py-1 px-2 rounded transition-colors ${
+                      isActive
+                        ? 'bg-blue-100 text-blue-700 font-medium'
+                        : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
+                    }`}
+                    onClick={onClose}
+                  >
+                    {page.title}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </aside>
+    </>
   );
 }

--- a/apps/client/src/app/article/[id]/_components/toc-sidebar.tsx
+++ b/apps/client/src/app/article/[id]/_components/toc-sidebar.tsx
@@ -82,15 +82,7 @@ export function TocSidebar({ toc }: TocSidebarProps) {
   }
 
   return (
-    <aside
-      className="w-60 border-l border-gray-200 bg-gray-50 p-6 overflow-y-auto"
-      style={{
-        position: 'fixed',
-        top: '64px',
-        right: 0,
-        height: 'calc(100vh - 64px)',
-      }}
-    >
+    <aside className="hidden lg:block fixed top-16 right-0 w-60 h-[calc(100vh-4rem)] border-l border-gray-200 bg-gray-50 p-6 overflow-y-auto">
       <nav>
         <h2 className="text-sm font-semibold text-gray-900 mb-4">目次</h2>
         <ul className="space-y-2">

--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -6,58 +6,22 @@ export default function HomePage() {
   const { data, isLoading } = useArticleListQuery();
 
   return (
-    <div style={{ minHeight: '100vh' }}>
-      <div style={{ marginBottom: '48px' }}>
-        <h1
-          style={{
-            fontSize: '48px',
-            fontWeight: 'bold',
-            color: '#111827',
-            marginBottom: '16px',
-          }}
-        >
-          記事一覧
-        </h1>
-        <p
-          style={{
-            fontSize: '20px',
-            color: '#6B7280',
-          }}
-        >
-          技術記事やチュートリアルを掲載しています
-        </p>
+    <div className="min-h-screen">
+      <div className="mb-8 md:mb-10 lg:mb-12">
+        <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 mb-3 md:mb-4">記事一覧</h1>
+        <p className="text-base md:text-lg lg:text-xl text-gray-600">技術記事やチュートリアルを掲載しています</p>
       </div>
 
       {isLoading ? (
-        <div
-          style={{
-            textAlign: 'center',
-            padding: '96px 0',
-            backgroundColor: '#F9FAFB',
-            borderRadius: '8px',
-          }}
-        >
-          <p style={{ fontSize: '18px', color: '#6B7280' }}>読み込み中...</p>
+        <div className="text-center py-16 md:py-20 lg:py-24 bg-gray-50 rounded-lg">
+          <p className="text-base md:text-lg text-gray-600">読み込み中...</p>
         </div>
       ) : !data || data.articleList.length === 0 ? (
-        <div
-          style={{
-            textAlign: 'center',
-            padding: '96px 0',
-            backgroundColor: '#F9FAFB',
-            borderRadius: '8px',
-          }}
-        >
-          <p style={{ fontSize: '18px', color: '#6B7280' }}>記事がありません</p>
+        <div className="text-center py-16 md:py-20 lg:py-24 bg-gray-50 rounded-lg">
+          <p className="text-base md:text-lg text-gray-600">記事がありません</p>
         </div>
       ) : (
-        <div
-          style={{
-            display: 'grid',
-            gap: '32px',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
-          }}
-        >
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
           {data.articleList.map((article) => (
             <ArticleCard key={article.id} article={article} />
           ))}

--- a/apps/client/src/domains/article-list/components/article-card.tsx
+++ b/apps/client/src/domains/article-list/components/article-card.tsx
@@ -8,86 +8,21 @@ interface ArticleCardProps {
 
 export function ArticleCard({ article }: ArticleCardProps) {
   return (
-    <article
-      style={{
-        backgroundColor: 'white',
-        borderRadius: '12px',
-        boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-        padding: '24px',
-        position: 'relative',
-        marginBottom: '24px',
-        transition: 'box-shadow 0.3s ease',
-        cursor: 'pointer',
-      }}
-      onMouseEnter={(e) => (e.currentTarget.style.boxShadow = '0 10px 15px rgba(0, 0, 0, 0.15)')}
-      onMouseLeave={(e) => (e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.1)')}
-    >
-      <Link
-        href={`/article/${article.id}`}
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          zIndex: 1,
-        }}
-      />
-      <div style={{ position: 'relative', pointerEvents: 'none' }}>
-        <h2
-          style={{
-            fontSize: '24px',
-            fontWeight: 'bold',
-            marginBottom: '12px',
-            color: '#111827',
-          }}
-        >
-          {article.title}
-        </h2>
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '8px',
-            marginBottom: '16px',
-          }}
-        >
+    <article className="bg-white rounded-xl shadow-md hover:shadow-xl p-5 md:p-6 relative transition-shadow duration-300 cursor-pointer">
+      <Link href={`/article/${article.id}`} className="absolute inset-0 z-10" />
+      <div className="relative pointer-events-none">
+        <h2 className="text-xl md:text-2xl font-bold mb-3 text-gray-900">{article.title}</h2>
+        <div className="flex flex-wrap gap-2 mb-4">
           {article.tags.map((tag) => (
-            <span
-              key={tag}
-              style={{
-                backgroundColor: '#DBEAFE',
-                color: '#1D4ED8',
-                padding: '4px 12px',
-                borderRadius: '9999px',
-                fontSize: '12px',
-                fontWeight: '500',
-              }}
-            >
+            <span key={tag} className="bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-xs font-medium">
               {tag}
             </span>
           ))}
         </div>
 
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            paddingTop: '16px',
-            borderTop: '1px solid #E5E7EB',
-            fontSize: '14px',
-          }}
-        >
-          <time style={{ color: '#6B7280' }}>{new Date(article.createdAt).toLocaleDateString()}</time>
-          <span
-            style={{
-              color: '#2563EB',
-              fontWeight: '500',
-            }}
-          >
-            続きを読む →
-          </span>
+        <div className="flex justify-between items-center pt-4 border-t border-gray-200 text-sm">
+          <time className="text-gray-600">{new Date(article.createdAt).toLocaleDateString()}</time>
+          <span className="text-blue-600 font-medium">続きを読む →</span>
         </div>
       </div>
     </article>


### PR DESCRIPTION
## 概要
記事一覧ページと記事詳細ページをモバイル・タブレット・デスクトップの各画面サイズに最適化しました。

## 変更内容

### 記事一覧ページ
- グリッドレイアウトをレスポンシブ化
  - モバイル: 1カラム
  - タブレット: 2カラム
  - デスクトップ: 3カラム
- インラインスタイルをTailwindクラスに変換
- フォントサイズとパディングをレスポンシブ対応

### 記事詳細ページ
- 左サイドバー（ページ一覧）をドロワー形式に変更
  - モバイル・タブレット: ハンバーガーメニューから開閉
  - デスクトップ: 固定サイドバー
- 右サイドバー（見出し目次）をデスクトップのみ表示
- ハンバーガーメニューボタンの実装
- メインコンテンツのレスポンシブ調整
- ページナビゲーションのレイアウト変更（モバイルは縦並び）

## 技術的な詳細
- Tailwindのレスポンシブユーティリティクラス（sm:, md:, lg:）を活用
- ブレークポイント: モバイル（~768px）、タブレット（768~1024px）、デスクトップ（1024px~）
- アクセシビリティ対応（ARIA属性、キーボード操作）

## 動作確認
- [x] モバイル表示でハンバーガーメニューが正常に動作する
- [x] タブレット表示で適切なレイアウトになる
- [x] デスクトップ表示で従来通りの表示になる
- [x] 画面サイズの変更時にレイアウトが適切に切り替わる