### PR TITLE
fix: シード処理のユーザー特定をPublic IDに変更し、401エラー時のリダイレクトを廃止

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -64,4 +64,3 @@ jobs:
             BASIC_AUTH_USER=${{ secrets.BASIC_AUTH_USER }}
             BASIC_AUTH_PASSWORD=${{ secrets.BASIC_AUTH_PASSWORD }}
             ALLOWED_EMAILS=${{ secrets.ALLOWED_EMAILS }}
-            SEED_USER_ID=${{ secrets.SEED_USER_ID }}

--- a/.github/workflows/cd-db.yml
+++ b/.github/workflows/cd-db.yml
@@ -74,5 +74,5 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
-          SEED_USER_ID: ${{ secrets.SEED_USER_ID }}
+          SEED_USER_PUBLIC_ID: ${{ secrets.SEED_USER_PUBLIC_ID }}
         run: pnpm seed

--- a/apps/client/src/app/providers.tsx
+++ b/apps/client/src/app/providers.tsx
@@ -17,8 +17,11 @@ export function Providers({ children }: { children: ReactNode }) {
   const handleApiError = (error: unknown): boolean => {
     if (error instanceof ApiError) {
       const status = error.statusCode;
+      // 401の場合はリダイレクトせず、必要に応じてエラー表示を行うか何もしない
       if (status === 401) {
-        router.push('/login');
+        // 管理者機能などの保護されたルートでのみログイン画面への遷移が必要な場合は
+        // 個別のコンポーネントやガード処理で対応する方針とするため、
+        // ここでのグローバルなリダイレクトは行わない。
         return true;
       }
       if (status === 403 || status === 404) {

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -28,5 +28,5 @@ BASIC_AUTH_USER=your_username
 BASIC_AUTH_PASSWORD=your_password
 ALLOWED_EMAILS=allowed1@example.com,allowed2@example.com
 
-# User Id
-SEED_USER_ID=user_id
+# User Public Id
+SEED_USER_PUBLIC_ID=user_public_id

--- a/apps/server/prisma/seed/upsert-articles.ts
+++ b/apps/server/prisma/seed/upsert-articles.ts
@@ -74,24 +74,21 @@ function getArticleFolders(articlesDir: string): string[] {
 async function main() {
   console.log('記事投入処理を開始します...');
 
-  // 環境変数からユーザーIDを取得
-  const userIdStr = process.env.SEED_USER_ID;
-  if (!userIdStr) {
-    throw new Error('環境変数 SEED_USER_ID が設定されていません');
-  }
-  const userId = parseInt(userIdStr, 10);
-  if (isNaN(userId)) {
-    throw new Error('環境変数 SEED_USER_ID は数値である必要があります');
+  // 環境変数からユーザーPublic IDを取得
+  const userPublicId = process.env.SEED_USER_PUBLIC_ID;
+  if (!userPublicId) {
+    throw new Error('環境変数 SEED_USER_PUBLIC_ID が設定されていません');
   }
 
   // ユーザーの存在確認
   const user = await prisma.user.findUnique({
-    where: { id: userId },
+    where: { publicId: userPublicId },
   });
   if (!user) {
-    throw new Error(`ユーザーID ${userId} が見つかりません`);
+    throw new Error(`ユーザー (PublicID: ${userPublicId}) が見つかりません`);
   }
-  console.log(`ユーザー: ${user.email} (ID: ${userId})`);
+  const userId = user.id;
+  console.log(`ユーザーの存在を確認しました (PublicID: ${userPublicId})`);
 
   // 記事フォルダのパス
   const articlesDir = join(__dirname, '../assets/articles');

--- a/apps/server/turbo.json
+++ b/apps/server/turbo.json
@@ -19,10 +19,7 @@
       ]
     },
     "seed": {
-      "env": ["SEED_USER_ID"]
-    },
-    "seed:upsert": {
-      "env": ["SEED_USER_ID"]
+      "env": ["SEED_USER_PUBLIC_ID"]
     },
     "lint": {
       "env": ["NODE_ENV", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]


### PR DESCRIPTION
## 変更内容
- upsert-articles.ts シードスクリプトにおいて、ユーザー特定を内部ID (id) からPublic ID (publicId) に変更しました。
- クライアントサイド (apps/client/src/app/providers.tsx) において、401エラー発生時の自動リダイレクト処理を廃止しました。
- CI/CDワークフロー (.github/workflows) および turbo.json の環境変数を更新し、SEED_USER_ID から SEED_USER_PUBLIC_ID へ移行しました。

## 目的
- シードデータの冪等性と環境可搬性の向上
- 認証エラー時のユーザー体験の改善（予期しないリダイレクトの防止）