### PR TITLE
fix(content): correct prisma generate command in workflow

### DIFF
--- a/.github/workflows/cd-database.yml
+++ b/.github/workflows/cd-database.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Generate Prisma Client
         working-directory: apps/content
-        run: pnpm prisma build
+        run: pnpm prisma generate
 
       - name: Seed Articles
         working-directory: apps/content

--- a/apps/content/package.json
+++ b/apps/content/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "prisma generate",
     "lint": "eslint scripts --config eslint.config.mjs --max-warnings 0",
     "format": "prettier --check \"scripts/**/*.ts\"",
     "format:fix": "prettier --write \"scripts/**/*.ts\"",


### PR DESCRIPTION
## 概要
cd-database.yml の Prisma コマンドを修正

## 変更内容
- `pnpm prisma build` → `pnpm prisma generate` に修正
- apps/content/package.json から不要な `build` スクリプトを削除