### PR TITLE
Release: NestJS + esbuild + Vitest article

### DIFF
--- a/apps/content/articles/05-nestjs-esbuild-vitest/00-metadata.json
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/00-metadata.json
@@ -1,0 +1,50 @@
+{
+  "publicId": "jkah04byk33ke0fjiqh7ihkj",
+  "title": "NestJS + esbuild + Vitest 高速開発環境ガイド",
+  "description": "Prisma 7.x の ESModule 標準化で NestJS ビルドに困っている方へ。esbuild + SWC による解決策から、Vitest による高速テスト、モダンな TypeScript/ESLint 設定、Vertical Slice Architecture まで、モダンな開発環境を構築するテンプレートを解説します。",
+  "tags": [
+    "NestJS",
+    "esbuild",
+    "Vitest",
+    "Prisma"
+  ],
+  "status": "PUBLIC",
+  "pages": [
+    {
+      "publicId": "k6cclwusg7xvilr5n7grsxom",
+      "file": "01-overview.md",
+      "level": 1,
+      "order": 1
+    },
+    {
+      "publicId": "wepxv0a1k3mj3cb5tm4su2zn",
+      "file": "02-prisma-esmodule-problem.md",
+      "level": 1,
+      "order": 2
+    },
+    {
+      "publicId": "lf987iq9xj7nbkuj6ywgr1g4",
+      "file": "03-esbuild-swc-build.md",
+      "level": 1,
+      "order": 3
+    },
+    {
+      "publicId": "dbflv1h8fvb5krjcm2hp8f38",
+      "file": "04-vitest-swc-test.md",
+      "level": 1,
+      "order": 4
+    },
+    {
+      "publicId": "mt47fs272akoshkyedpywr56",
+      "file": "05-typescript-eslint-config.md",
+      "level": 1,
+      "order": 5
+    },
+    {
+      "publicId": "tgkussdd7a863e38ax4hv9g9",
+      "file": "06-architecture.md",
+      "level": 1,
+      "order": 6
+    }
+  ]
+}

--- a/apps/content/articles/05-nestjs-esbuild-vitest/01-overview.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/01-overview.md
@@ -1,0 +1,97 @@
+---
+title: 概要
+description: NestJS + esbuild + Vitest を使用した高速開発環境テンプレートの特徴と、Prisma ESModule 化に伴う課題の解決方法を解説します。
+---
+
+本シリーズでは、**NestJS + esbuild + Vitest** を使用した高速開発環境のモノレポテンプレートを解説します。
+
+テンプレートリポジトリ: [GitHub - nestjs-esbuild-vitest](https://github.com/your-username/nestjs-esbuild-vitest)
+
+## こんな方へ
+
+Prisma 7.x 以降の ESModule 標準化により、従来の NestJS ビルド環境が動作しなくなった方向けのテンプレートです。
+
+- **CommonJS 環境** で本番ビルドのパス解決が失敗する
+- **NestJS の SWC ビルド** で拡張子付与が必要になり困っている
+- **tsc や swc 単体** では ESModule 環境に対応できない
+
+これらの問題を **esbuild + SWC** で解決し、さらにビルド・テストを劇的に高速化します。
+
+## 特徴
+
+このテンプレートは、以下の特徴を持つモダンな開発環境を提供します。
+
+| 機能                    | 説明                                         |
+| ----------------------- | -------------------------------------------- |
+| **esbuild + SWC**       | NestJS のデコレーターに対応した超高速ビルド  |
+| **Vitest**              | SWC を使った高速なユニット/E2E テスト        |
+| **Prisma**              | ESModule 対応の型安全な ORM                  |
+| **Turborepo**           | 高速なビルドシステムとキャッシング           |
+| **pnpm Catalogs**       | 依存関係のバージョンを一元管理               |
+| **ESLint Flat Config**  | 最新の ESLint 設定形式 + アーキテクチャ検証  |
+| **GitHub Actions CI**   | 自動テスト・ビルド                           |
+
+## 開発体験の改善
+
+従来の tsc + Jest 環境と比較して、ビルドとテストが劇的に高速化されています。
+
+| 項目           | 従来（tsc + Jest） | 現在（esbuild + Vitest） | 改善率        |
+| -------------- | ------------------ | ------------------------ | ------------- |
+| ビルド         | 20〜30 秒          | **200〜500 ミリ秒**      | 約 50〜100 倍 |
+| テスト起動     | 5〜10 秒           | **500 ミリ秒〜1 秒**     | 約 10〜20 倍  |
+| ホットリロード | 非対応             | **対応**                 | -             |
+
+この高速化により、開発中のフィードバックループが劇的に短縮されます。
+
+## プロジェクト構成
+
+```
+nestjs-esbuild-vitest/
+├── apps/
+│   └── server/             # NestJS サーバー
+├── packages/
+│   ├── database/           # Prisma データベース設定
+│   ├── eslint-config/      # 共有 ESLint 設定
+│   └── typescript-config/  # 共有 TypeScript 設定
+├── turbo.json              # Turborepo 設定
+└── pnpm-workspace.yaml     # pnpm ワークスペース設定
+```
+
+## セットアップ
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/your-username/nestjs-esbuild-vitest.git
+cd nestjs-esbuild-vitest
+
+# 依存関係をインストール
+pnpm install
+
+# すべてのチェックを実行
+pnpm check-all
+```
+
+## コマンド一覧
+
+| コマンド             | 説明                            |
+| -------------------- | ------------------------------- |
+| `pnpm build`         | すべてのパッケージをビルド      |
+| `pnpm start`         | 開発サーバーを起動              |
+| `pnpm check-all`     | lint, format, tsc, test を実行  |
+| `pnpm lint`          | ESLint を実行                   |
+| `pnpm format`        | Prettier でフォーマットチェック |
+| `pnpm tsc`           | TypeScript 型チェック           |
+| `pnpm test`          | テストを実行                    |
+| `pnpm test:coverage` | カバレッジ付きテスト            |
+| `pnpm clean`         | ビルド成果物を削除              |
+
+## 次のステップ
+
+以降のページでは、各機能について詳しく解説します。
+
+1. **Prisma ESModule 化の課題** - なぜ従来のビルド方法では対応できないのか
+2. **esbuild + SWC ビルドシステム** - 問題の解決策と設定方法
+3. **Vitest + SWC テスト環境** - 高速なテスト環境の構築
+4. **TypeScript / ESLint 設定** - モダンな設定ファイルの解説
+5. **アーキテクチャ設計** - Vertical Slice Architecture と CQRS
+

--- a/apps/content/articles/05-nestjs-esbuild-vitest/02-prisma-esmodule-problem.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/02-prisma-esmodule-problem.md
@@ -1,0 +1,132 @@
+---
+title: Prisma ESModule 化の課題
+description: Prisma 7.x 以降の ESModule 標準化により、NestJS の従来のビルド方法では対応できなくなった背景と課題を解説します。
+---
+
+## Prisma 7.x の ESModule 標準化
+
+Prisma 7.x 以降、`@prisma/client` は **ESModule** として提供されるようになりました。これは Node.js エコシステム全体が ESModule へ移行している流れに沿った変更です。
+
+```javascript
+// Prisma 7.x 以降
+import { PrismaClient } from '@prisma/client';
+
+// 従来の CommonJS
+const { PrismaClient } = require('@prisma/client');
+```
+
+この変更自体は正しい方向性ですが、NestJS プロジェクトでは深刻な問題を引き起こしました。
+
+## NestJS + CommonJS 環境での問題
+
+### 本番環境でのパス解決失敗
+
+従来の NestJS プロジェクトは CommonJS（`"type": "commonjs"` または未指定）で構成されていました。この環境で Prisma 7.x を使用すると、**本番ビルド時にパス解決が失敗**します。
+
+```
+Error: Cannot find module '@prisma/client'
+```
+
+これは、ESModule 形式の `@prisma/client` を CommonJS 環境で正しくインポートできないことが原因です。
+
+### 開発環境と本番環境の乖離
+
+特に厄介なのは、**開発環境では動作するのに本番環境で失敗する**ケースです。
+
+| 環境     | 動作状況 | 理由                                   |
+| -------- | -------- | -------------------------------------- |
+| 開発環境 | ✅ 動作   | ts-node や tsx が動的にトランスパイル  |
+| 本番環境 | ❌ 失敗   | tsc でビルドした JavaScript が動作しない |
+
+この乖離は、デプロイ時まで問題に気づけないという深刻な事態を招きます。
+
+## NestJS + SWC ビルドでの問題
+
+### 拡張子付与の必要性
+
+「では ESModule 環境（`"type": "module"`）に移行すればいいのでは？」と考えるかもしれません。しかし、NestJS の SWC ビルド（`nest build --builder swc`）を使用すると、別の問題が発生します。
+
+ESModule 環境では、**インポートパスに拡張子を明示的に付与する必要があります**。
+
+```typescript
+// ESModule 環境で必要な書き方
+import { UserService } from './user.service.js';
+
+// 従来の書き方（ESModule 環境では動作しない）
+import { UserService } from './user.service';
+```
+
+NestJS の SWC ビルドは、この拡張子付与を**自動で行いません**。つまり、すべてのインポートを手動で書き換える必要があります。
+
+### 実用的ではない解決策
+
+既存のコードベースで数百〜数千のインポート文を書き換えるのは現実的ではありません。また、IDE の補完機能も `.js` 拡張子を自動で付与してくれないため、開発体験が大幅に低下します。
+
+## tsc 単体では対応できない理由
+
+### パスエイリアスの解決不可
+
+TypeScript コンパイラ（tsc）は、`tsconfig.json` で設定した**パスエイリアスを解決しません**。
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "$domains/*": ["src/domains/*"],
+      "$shared/*": ["src/shared/*"]
+    }
+  }
+}
+```
+
+```typescript
+// ソースコード
+import { UserService } from '$domains/user/user.service';
+
+// tsc の出力（パスエイリアスがそのまま）
+import { UserService } from '$domains/user/user.service';
+// → 実行時エラー: Cannot find module '$domains/user/user.service'
+```
+
+tsc はあくまで型チェックとトランスパイルを行うだけで、モジュール解決は行いません。
+
+### バンドル機能の欠如
+
+tsc には**バンドル機能がありません**。ESModule 環境で Prisma クライアントを含む複雑な依存関係を正しく解決するには、バンドラーが必要です。
+
+## swc 単体では対応できない理由
+
+SWC は高速なトランスパイラですが、tsc と同様に以下の問題があります。
+
+1. **パスエイリアスを解決しない**
+2. **バンドル機能がない**
+3. **ESModule 環境での拡張子付与を行わない**
+
+NestJS CLI の `--builder swc` オプションは、SWC をトランスパイラとして使用するだけで、これらの問題は解決しません。
+
+## ESModule 移行の必然性
+
+Node.js エコシステムは ESModule へ向かっています。Prisma だけでなく、今後も多くのライブラリが ESModule 専用になっていくでしょう。
+
+| ライブラリ      | ESModule 対応状況                    |
+| --------------- | ------------------------------------ |
+| Prisma 7.x+     | ESModule のみ                        |
+| chalk 5.x+      | ESModule のみ                        |
+| node-fetch 3.x+ | ESModule のみ                        |
+| その他多数      | 順次 ESModule へ移行中               |
+
+CommonJS に固執することは、将来的にエコシステムから取り残されるリスクがあります。
+
+## 解決策: esbuild
+
+これらの問題をすべて解決するのが **esbuild** です。次のページでは、esbuild を使用したビルドシステムの構築方法を解説します。
+
+esbuild は以下を実現します。
+
+- ✅ パスエイリアスの解決
+- ✅ ESModule 形式での出力
+- ✅ Prisma クライアントを含む依存関係の正しいバンドル
+- ✅ 劇的に高速なビルド（数百ミリ秒）
+- ✅ NestJS デコレーターのサポート（SWC プラグイン併用）
+

--- a/apps/content/articles/05-nestjs-esbuild-vitest/03-esbuild-swc-build.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/03-esbuild-swc-build.md
@@ -1,0 +1,286 @@
+---
+title: esbuild + SWC ビルドシステム
+description: Prisma ESModule 問題を解決するための esbuild + SWC によるビルドシステムの構築方法を解説します。
+---
+
+## esbuild を採用した経緯
+
+前章で解説した通り、Prisma 7.x の ESModule 化により、従来のビルド方法では対応できなくなりました。esbuild は以下の理由で採用しました。
+
+| 課題                   | esbuild での解決策                     |
+| ---------------------- | -------------------------------------- |
+| パスエイリアス解決     | ✅ ビルド時に解決                       |
+| ESModule 形式出力      | ✅ `format: 'esm'` で対応               |
+| Prisma クライアント    | ✅ 正しくバンドル/外部化                |
+| ビルド速度             | ✅ 数百ミリ秒（従来比 50〜100 倍高速）  |
+
+## SWC プラグインによるデコレーターサポート
+
+### 問題: esbuild 単体ではデコレーターメタデータに非対応
+
+NestJS は TypeScript のデコレーターを多用しますが、esbuild 単体では `emitDecoratorMetadata`（デコレーターメタデータの生成）をサポートしていません。
+
+```typescript
+// NestJS のコード例
+@Injectable()
+export class UserService {
+  constructor(private readonly prisma: PrismaAdapter) {}
+}
+```
+
+このコードが正しく動作するには、デコレーターメタデータが必要です。
+
+### 解決策: SWC を esbuild のプラグインとして使用
+
+SWC はデコレーターメタデータをサポートしています。esbuild のプラグイン機構を使って、TypeScript ファイルを SWC で変換してから esbuild でバンドルします。
+
+```javascript
+// esbuild.config.mjs
+import * as esbuild from 'esbuild';
+import * as swc from '@swc/core';
+import fs from 'node:fs';
+
+/**
+ * SWC を使ってデコレーターをサポートする esbuild プラグイン
+ */
+function swcPlugin() {
+  return {
+    name: 'swc-decorator',
+    setup(build) {
+      build.onLoad({ filter: /\.ts$/ }, async (args) => {
+        const source = await fs.promises.readFile(args.path, 'utf8');
+        const result = await swc.transform(source, {
+          filename: args.path,
+          sourceMaps: true,
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              decorators: true,
+            },
+            transform: {
+              legacyDecorator: true,
+              decoratorMetadata: true, // ここがポイント
+            },
+            target: 'es2023',
+            keepClassNames: true,
+          },
+        });
+        return {
+          contents: result.code,
+          loader: 'js',
+        };
+      });
+    },
+  };
+}
+```
+
+**ポイント:**
+
+- `decoratorMetadata: true` でデコレーターメタデータを生成
+- `legacyDecorator: true` で TypeScript のレガシーデコレーター構文をサポート
+- `keepClassNames: true` でクラス名を維持（DI コンテナで必要）
+
+## esbuild 設定の全体像
+
+```javascript
+// esbuild.config.mjs
+import * as esbuild from 'esbuild';
+import * as swc from '@swc/core';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const isWatch = process.argv.includes('--watch');
+const isDebug = process.argv.includes('--debug');
+
+// package.json から dependencies を読み取り、外部化するパッケージを取得
+const packageJson = JSON.parse(
+  fs.readFileSync(path.resolve(dirname, 'package.json'), 'utf-8')
+);
+const externalPackages = [
+  ...Object.keys(packageJson.dependencies || {}),
+  ...Object.keys(packageJson.devDependencies || {}),
+  '@prisma/client',
+].filter((pkg) => !pkg.startsWith('@monorepo/'));
+
+/** @type {esbuild.BuildOptions} */
+const config = {
+  entryPoints: [path.resolve(dirname, 'src/main.ts')],
+  bundle: true,
+  platform: 'node',
+  target: 'node24',
+  outfile: path.resolve(dirname, 'dist/main.js'),
+  format: 'esm',
+  sourcemap: isWatch,
+  external: externalPackages,
+  banner: {
+    js: "import 'reflect-metadata';",
+  },
+  plugins: [swcPlugin()],
+  logLevel: 'info',
+};
+```
+
+### 設定のポイント
+
+#### format: 'esm'
+
+ESModule 形式で出力します。これにより、Prisma 7.x を正しくインポートできます。
+
+#### external: externalPackages
+
+node_modules のパッケージは外部化（バンドルしない）します。ただし、モノレポ内のパッケージ（`@monorepo/`）はバンドルに含めます。
+
+```javascript
+.filter((pkg) => !pkg.startsWith('@monorepo/'));
+```
+
+#### banner による reflect-metadata インポート
+
+NestJS は `reflect-metadata` を必要とします。バナー機能で出力ファイルの先頭にインポート文を追加します。
+
+```javascript
+banner: {
+  js: "import 'reflect-metadata';",
+},
+```
+
+## ホットリロード対応の開発サーバー
+
+esbuild の watch モードを使用して、ファイル変更時に自動でリビルド＆サーバー再起動を行います。
+
+```javascript
+// esbuild.config.mjs（続き）
+class NodeProcess {
+  process = null;
+
+  start() {
+    const args = [path.resolve(dirname, 'dist/main.js')];
+    if (isDebug) {
+      args.unshift('--inspect=0.0.0.0:9229');
+    }
+    console.log(`🚀 Starting server${isDebug ? ' with debugger' : ''}...`);
+    this.process = spawn('node', args, {
+      stdio: 'inherit',
+      cwd: dirname,
+    });
+  }
+
+  restart() {
+    if (this.process) {
+      console.log('🔄 Restarting server...');
+      this.process.kill('SIGTERM');
+      this.process.on('exit', () => this.start());
+    } else {
+      this.start();
+    }
+  }
+
+  stop() {
+    if (this.process) {
+      this.process.kill('SIGTERM');
+      this.process = null;
+    }
+  }
+}
+
+async function build() {
+  if (isWatch) {
+    const nodeProcess = new NodeProcess();
+
+    const restartPlugin = {
+      name: 'restart-server',
+      setup(build) {
+        build.onEnd((result) => {
+          if (result.errors.length === 0) {
+            nodeProcess.restart();
+          }
+        });
+      },
+    };
+
+    const ctx = await esbuild.context({
+      ...config,
+      plugins: [...(config.plugins || []), restartPlugin],
+    });
+
+    process.on('SIGINT', async () => {
+      console.log('👋 Shutting down...');
+      nodeProcess.stop();
+      await ctx.dispose();
+      process.exit(0);
+    });
+
+    await ctx.watch();
+    console.log('👀 Watching for changes...');
+  } else {
+    await esbuild.build(config);
+    console.log('✅ Build complete!');
+  }
+}
+
+build();
+```
+
+### 使用方法
+
+```bash
+# 開発サーバーを起動（ホットリロード）
+node esbuild.config.mjs --watch
+
+# デバッガー付きで起動
+node esbuild.config.mjs --watch --debug
+
+# 本番ビルド
+node esbuild.config.mjs
+```
+
+## デバッガー対応
+
+`--debug` フラグを使用すると、Node.js のインスペクターがポート 9229 で起動します。VS Code からアタッチしてデバッグできます。
+
+### VS Code の launch.json
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Server",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}
+```
+
+## package.json のスクリプト設定
+
+```json
+{
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "start": "node esbuild.config.mjs --watch",
+    "start:debug": "node esbuild.config.mjs --watch --debug",
+    "start:prod": "node dist/main.js"
+  }
+}
+```
+
+## まとめ
+
+esbuild + SWC の組み合わせにより、以下を実現しています。
+
+1. **Prisma ESModule 問題の解決** - ESModule 形式での正しいビルド
+2. **NestJS デコレーターのサポート** - SWC プラグインによるメタデータ生成
+3. **劇的な高速化** - 数百ミリ秒でビルド完了
+4. **優れた開発体験** - ホットリロード + デバッガー対応
+
+次のページでは、テスト環境（Vitest + SWC）の構築方法を解説します。
+

--- a/apps/content/articles/05-nestjs-esbuild-vitest/04-vitest-swc-test.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/04-vitest-swc-test.md
@@ -1,0 +1,286 @@
+---
+title: Vitest + SWC テスト環境
+description: Vitest と SWC を使用した高速なテスト環境の構築方法を解説します。Jest からの移行ポイントも紹介します。
+---
+
+## なぜ Vitest を使うのか
+
+Jest と比較して、Vitest には以下の利点があります。
+
+| 観点           | Jest                          | Vitest                        |
+| -------------- | ----------------------------- | ----------------------------- |
+| 起動速度       | 5〜10 秒                      | **500 ミリ秒〜1 秒**          |
+| ESModule 対応  | 設定が複雑                    | **ネイティブサポート**        |
+| トランスパイル | ts-jest（遅い）               | **SWC（高速）**               |
+| 設定ファイル   | jest.config.js + babel.config | **vitest.config.ts のみ**     |
+| Watch モード   | 遅い                          | **高速**                      |
+
+特に ESModule 環境では、Jest の設定が複雑になりがちですが、Vitest ではシンプルに対応できます。
+
+## テストの種類
+
+テストは 2 種類に分離しています。
+
+| テスト種別     | ファイルパターン | 説明                   |
+| -------------- | ---------------- | ---------------------- |
+| ユニットテスト | `*.test.ts`      | 単体機能のテスト       |
+| E2E テスト     | `*.spec.ts`      | エンドツーエンドテスト |
+
+この分離により、目的に応じたテスト実行が可能です。
+
+```bash
+# ユニットテストのみ実行
+pnpm vitest run --project unit
+
+# E2E テストのみ実行
+pnpm vitest run --project e2e
+
+# 全テスト実行
+pnpm vitest run
+```
+
+## SWC による高速トランスパイル
+
+ビルドシステムと同様に、テスト環境でも SWC を使用してデコレーターを変換しています。
+
+```typescript
+// vitest.config.ts
+import 'reflect-metadata';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const swcPlugin = swc.vite({
+  sourceMaps: true,
+  jsc: {
+    parser: {
+      syntax: 'typescript',
+      decorators: true,
+      dynamicImport: true,
+    },
+    transform: {
+      legacyDecorator: true,
+      decoratorMetadata: true,
+    },
+    target: 'es2023',
+    keepClassNames: true,
+  },
+  module: { type: 'es6' },
+  minify: false,
+});
+```
+
+**ポイント:**
+
+- `unplugin-swc` を使用して Vite/Vitest と統合
+- esbuild プラグインと同じ SWC 設定（`decoratorMetadata: true`）
+- `sourceMaps: true` でデバッグ時のスタックトレースを改善
+
+## Vitest 設定の全体像
+
+```typescript
+// vitest.config.ts
+const resolveAlias = {
+  alias: {
+    $domains: path.resolve(dirname, 'src/domains'),
+    $shared: path.resolve(dirname, 'src/shared'),
+  },
+};
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        plugins: [swcPlugin],
+        resolve: resolveAlias,
+        test: {
+          name: 'unit',
+          globals: true,
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+      {
+        plugins: [swcPlugin],
+        resolve: resolveAlias,
+        test: {
+          name: 'e2e',
+          globals: true,
+          environment: 'node',
+          include: ['src/**/*.spec.ts'],
+        },
+      },
+    ],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+      reporter: ['text', 'json', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.dto.ts',
+        'src/**/index.ts',
+        'src/**/*.test.ts',
+        'src/**/*.spec.ts',
+        'src/main.ts',
+        'src/**/*.module.ts',
+      ],
+    },
+  },
+  resolve: resolveAlias,
+});
+```
+
+### 設定のポイント
+
+#### projects によるテスト分離
+
+`projects` 配列を使用して、ユニットテストと E2E テストを分離しています。それぞれに異なる設定を適用できます。
+
+```typescript
+projects: [
+  {
+    test: {
+      name: 'unit',
+      include: ['src/**/*.test.ts'],
+    },
+  },
+  {
+    test: {
+      name: 'e2e',
+      include: ['src/**/*.spec.ts'],
+    },
+  },
+],
+```
+
+#### パスエイリアスの設定
+
+`resolve.alias` でパスエイリアスを設定します。`tsconfig.json` の `paths` と一致させます。
+
+```typescript
+const resolveAlias = {
+  alias: {
+    $domains: path.resolve(dirname, 'src/domains'),
+    $shared: path.resolve(dirname, 'src/shared'),
+  },
+};
+```
+
+#### globals: true
+
+`describe`, `it`, `expect` などのグローバル関数を有効化します。インポート不要でテストを記述できます。
+
+```typescript
+// globals: true の場合
+describe('UserService', () => {
+  it('should return user', () => {
+    expect(result).toBeDefined();
+  });
+});
+
+// globals: false の場合（インポート必要）
+import { describe, it, expect } from 'vitest';
+```
+
+## V8 カバレッジ
+
+V8 エンジンのネイティブカバレッジ機能を使用しており、高速にカバレッジレポートを生成できます。
+
+```typescript
+coverage: {
+  provider: 'v8',
+  reportsDirectory: './coverage',
+  reporter: ['text', 'json', 'lcov'],
+  include: ['src/**/*.ts'],
+  exclude: [
+    'src/**/*.dto.ts',
+    'src/**/index.ts',
+    'src/**/*.test.ts',
+    'src/**/*.spec.ts',
+    'src/main.ts',
+    'src/**/*.module.ts',
+  ],
+},
+```
+
+### 除外対象
+
+以下のファイルはカバレッジから除外しています。
+
+| ファイル        | 理由                           |
+| --------------- | ------------------------------ |
+| `*.dto.ts`      | データ定義のみ、ロジックなし   |
+| `index.ts`      | 再エクスポートのみ             |
+| `*.test.ts`     | テストファイル自体             |
+| `*.spec.ts`     | テストファイル自体             |
+| `main.ts`       | エントリーポイント             |
+| `*.module.ts`   | NestJS モジュール定義のみ      |
+
+### カバレッジ実行
+
+```bash
+# カバレッジ付きでテスト実行
+pnpm test:coverage
+```
+
+## package.json のスクリプト設定
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:unit": "vitest run --project unit",
+    "test:e2e": "vitest run --project e2e"
+  }
+}
+```
+
+## Jest からの移行
+
+Jest から Vitest への移行は比較的簡単です。
+
+### API の互換性
+
+Vitest は Jest とほぼ同じ API を提供しています。
+
+```typescript
+// Jest も Vitest も同じ
+describe('UserService', () => {
+  beforeEach(() => {
+    // setup
+  });
+
+  it('should return user', () => {
+    expect(result).toEqual({ id: 1, name: 'John' });
+  });
+});
+```
+
+### 主な違い
+
+| 機能              | Jest                      | Vitest                    |
+| ----------------- | ------------------------- | ------------------------- |
+| モック            | `jest.fn()`               | `vi.fn()`                 |
+| タイマー          | `jest.useFakeTimers()`    | `vi.useFakeTimers()`      |
+| スパイ            | `jest.spyOn()`            | `vi.spyOn()`              |
+| モジュールモック  | `jest.mock()`             | `vi.mock()`               |
+
+`jest` を `vi` に置き換えるだけで、ほとんどのテストが動作します。
+
+## まとめ
+
+Vitest + SWC の組み合わせにより、以下を実現しています。
+
+1. **高速な起動** - ESModule ネイティブで起動が速い
+2. **NestJS デコレーターのサポート** - SWC による高速トランスパイル
+3. **テストの分離** - ユニット/E2E テストを個別に実行可能
+4. **V8 カバレッジ** - 高速なカバレッジレポート生成
+5. **Jest との互換性** - 移行コストが低い
+
+次のページでは、TypeScript と ESLint の設定について解説します。
+

--- a/apps/content/articles/05-nestjs-esbuild-vitest/05-typescript-eslint-config.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/05-typescript-eslint-config.md
@@ -1,0 +1,297 @@
+---
+title: TypeScript / ESLint 設定
+description: モダンな TypeScript と ESLint Flat Config の設定方法を解説します。eslint-plugin-boundaries によるアーキテクチャ検証も紹介します。
+---
+
+## TypeScript 設定
+
+### 共有設定パッケージ
+
+TypeScript の基本設定は `@monorepo/typescript-config` パッケージで一元管理しています。
+
+```json
+// packages/typescript-config/tsconfig.json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "removeComments": false,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "types": ["node"]
+  }
+}
+```
+
+### moduleResolution: "bundler" の意味
+
+`moduleResolution: "bundler"` は TypeScript 5.0 で導入されたモジュール解決戦略です。
+
+| 設定値    | 説明                                              |
+| --------- | ------------------------------------------------- |
+| `node`    | Node.js の CommonJS 解決アルゴリズム              |
+| `node16`  | Node.js の ESModule 対応解決（拡張子必須）        |
+| `bundler` | **バンドラー向け（拡張子省略可、ESModule 対応）** |
+
+esbuild を使用する場合、`bundler` が最適です。
+
+- ✅ 拡張子を省略してインポートできる
+- ✅ ESModule のセマンティクスに準拠
+- ✅ パスエイリアスとの相性が良い
+
+```typescript
+// moduleResolution: "bundler" では OK
+import { UserService } from './user.service';
+
+// moduleResolution: "node16" では NG（拡張子必須）
+import { UserService } from './user.service.js';
+```
+
+### パスエイリアスの設定
+
+サーバーアプリケーションでは、パスエイリアスを設定してインポートを簡潔にしています。
+
+```json
+// apps/server/tsconfig.json
+{
+  "extends": "@monorepo/typescript-config",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "$domains/*": ["src/domains/*"],
+      "$shared/*": ["src/shared/*"]
+    },
+    "target": "ES2023"
+  },
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.spec.json" }]
+}
+```
+
+**ポイント:**
+
+- `$domains/` と `$shared/` で明示的にパスを区別
+- `@` プレフィックスを避けることで、npm パッケージとの混同を防止
+- Project References で型チェックを分離
+
+### Project References による分離
+
+Project References を使用して、ビルド用とテスト用の設定を分離しています。
+
+```
+apps/server/
+├── tsconfig.json        # ベース設定 + references
+├── tsconfig.build.json  # 本番ビルド用
+└── tsconfig.spec.json   # テスト用
+```
+
+これにより、VS Code のエディタ内型チェックと CLI の tsc コマンドで同じ挙動を実現します。
+
+## ESLint Flat Config
+
+### 共有設定パッケージ
+
+ESLint の設定も `@monorepo/eslint-config` パッケージで一元管理しています。ESLint 9.0 で導入された [Flat Config](https://eslint.org/docs/latest/use/configure/configuration-files-new) 形式を使用しています。
+
+```javascript
+// packages/eslint-config/index.js
+import js from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import boundariesPlugin from 'eslint-plugin-boundaries';
+import importPlugin from 'eslint-plugin-import';
+import turboPlugin from 'eslint-plugin-turbo';
+import tseslint from 'typescript-eslint';
+
+export const baseConfig = [
+  {
+    ignores: ['dist/**', 'build/**', 'node_modules/**', 'eslint.config.mjs'],
+  },
+  js.configs.recommended,
+  eslintConfigPrettier,
+  ...tseslint.configs.recommended,
+  {
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: ['apps/*/tsconfig.json', 'apps/*/tsconfig.spec.json', 'packages/*/tsconfig.json'],
+        },
+      },
+      'boundaries/elements': [
+        { type: 'domains', pattern: '$domains/**' },
+        { type: 'modules', pattern: '$modules/**' },
+        { type: 'shared', pattern: '$shared/**' },
+      ],
+    },
+    plugins: {
+      boundaries: boundariesPlugin,
+      import: importPlugin,
+      turbo: turboPlugin,
+    },
+    rules: {
+      // ... ルール設定
+    },
+  },
+];
+```
+
+### Flat Config の利点
+
+従来の `.eslintrc` 形式と比較して、以下の利点があります。
+
+| 観点               | .eslintrc 形式   | Flat Config                    |
+| ------------------ | ---------------- | ------------------------------ |
+| 設定形式           | JSON/YAML/JS     | **JavaScript のみ**            |
+| 型安全性           | なし             | **TypeScript 対応**            |
+| 設定の継承         | extends で複雑化 | **配列のスプレッドでシンプル** |
+| プラグイン読み込み | 文字列で指定     | **import で明示的**            |
+
+```javascript
+// Flat Config: 配列のスプレッドで継承
+export default [
+  ...baseConfig,
+  {
+    // パッケージ固有の設定
+  },
+];
+```
+
+### eslint-plugin-boundaries によるアーキテクチャ検証
+
+`eslint-plugin-boundaries` を使用して、アーキテクチャの依存関係を自動でチェックしています。
+
+```javascript
+'boundaries/element-types': [
+  'error',
+  {
+    default: 'allow',
+    rules: [
+      {
+        from: 'modules',
+        disallow: ['domains'],
+        message: 'Modules should not depend on domains.',
+      },
+      {
+        from: 'shared',
+        disallow: ['domains', 'modules'],
+        message: 'Shared should not depend on domains or modules.',
+      },
+    ],
+  },
+],
+```
+
+**依存関係のルール:**
+
+```
+domains/ ──参照可→ modules/ ──参照可→ shared/
+    │                 │
+    └──参照可─────────┘
+
+※ 逆方向の参照は禁止
+```
+
+| 参照元     | domains | modules | shared |
+| ---------- | ------- | ------- | ------ |
+| `domains/` | -       | ✅      | ✅     |
+| `modules/` | ❌      | -       | ✅     |
+| `shared/`  | ❌      | ❌      | -      |
+
+これにより、依存関係の逆転を防ぎ、アーキテクチャの整合性を維持します。
+
+### import/order による整列されたインポート順序
+
+インポート文を自動で整列し、一貫したコードスタイルを維持します。
+
+```javascript
+'import/order': [
+  'error',
+  {
+    groups: [
+      ['builtin', 'external'],
+      ['internal', 'parent', 'sibling', 'index', 'object'],
+      'type',
+    ],
+    pathGroups: [
+      {
+        pattern: '${domains,modules,shared}/**',
+        group: 'internal',
+      },
+    ],
+    alphabetize: {
+      order: 'asc',
+      caseInsensitive: true,
+      orderImportKind: 'asc',
+    },
+    'newlines-between': 'always',
+  },
+],
+```
+
+**整列結果:**
+
+```typescript
+// 1. builtin / external（Node.js 標準 + npm パッケージ）
+import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+// 2. internal（パスエイリアス）
+import { PrismaAdapter } from '$shared/adapters';
+import { UserRepository } from '$domains/user/repositories';
+
+// 3. type（型インポート）
+import type { User } from '$prisma/client';
+```
+
+### サーバー固有の ESLint 設定
+
+サーバーアプリケーションでは、共有設定を拡張して NestJS 向けの調整を行っています。
+
+```javascript
+// apps/server/eslint.config.mjs
+import { baseConfig } from '@monorepo/eslint-config';
+
+export default [
+  ...baseConfig,
+  {
+    ignores: ['*.config.cjs', '*.config.mjs'],
+  },
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+];
+```
+
+**ポイント:**
+
+- `projectService: true` で TypeScript Language Service と連携
+- `@typescript-eslint/no-explicit-any: 'off'` で NestJS の any 使用を許容
+
+## まとめ
+
+モダンな TypeScript / ESLint 設定により、以下を実現しています。
+
+1. **moduleResolution: "bundler"** - esbuild との相性が良いモジュール解決
+2. **Project References** - VS Code と tsc の挙動一致
+3. **ESLint Flat Config** - シンプルで型安全な設定
+4. **eslint-plugin-boundaries** - アーキテクチャの自動検証
+5. **import/order** - 一貫したインポート順序
+
+次のページでは、アーキテクチャ設計（Vertical Slice Architecture と CQRS）について解説します。

--- a/apps/content/articles/05-nestjs-esbuild-vitest/06-architecture.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/06-architecture.md
@@ -1,0 +1,252 @@
+---
+title: アーキテクチャ設計
+description: Vertical Slice Architecture と Clean Architecture（CQRS）を組み合わせたアーキテクチャ設計を解説します。
+---
+
+## アーキテクチャ概要
+
+このテンプレートでは、**Vertical Slice Architecture** と **Clean Architecture（CQRS）** を組み合わせた設計を採用しています。
+
+## Vertical Slice Architecture
+
+機能（ドメイン）ごとにコードを垂直に分割し、各スライスが独立して開発・テスト可能な構造です。
+
+### 利点
+
+| 観点               | 説明                                       |
+| ------------------ | ------------------------------------------ |
+| **凝集度が高い**   | 関連するコードが同じディレクトリにまとまる |
+| **変更の影響範囲** | 機能追加・修正が他のドメインに影響しにくい |
+| **スケーラブル**   | チームやマイクロサービスへの分割が容易     |
+| **認知しやすい**   | 機能ごとにファイルが整理され、理解しやすい |
+
+### 従来のレイヤードアーキテクチャとの比較
+
+```
+# レイヤードアーキテクチャ（横分割）
+src/
+├── controllers/
+│   ├── user.controller.ts
+│   └── product.controller.ts
+├── services/
+│   ├── user.service.ts
+│   └── product.service.ts
+└── repositories/
+    ├── user.repository.ts
+    └── product.repository.ts
+
+# Vertical Slice Architecture（縦分割）
+src/
+├── domains/
+│   ├── user/
+│   │   ├── user.controller.ts
+│   │   ├── user.service.ts
+│   │   └── user.repository.ts
+│   └── product/
+│       ├── product.controller.ts
+│       ├── product.service.ts
+│       └── product.repository.ts
+```
+
+Vertical Slice では、**ユーザー機能を変更するときに `domains/user/` だけを見れば良い**という利点があります。
+
+### 設計方針とトレードオフ
+
+各ドメインの**境界（コンテキスト）を明確化**することで、関心ごとの分離とコードの認知しやすさの向上を図っています。
+
+一方で、このアプローチでは**共通処理がドメインごとに重複する**ことがあります。これは意図的なトレードオフであり、ドメイン間の結合度を下げることを優先しています。
+
+## shared と modules の使い分け
+
+| 配置場所   | 用途                                                                  | 例                         |
+| ---------- | --------------------------------------------------------------------- | -------------------------- |
+| `shared/`  | インフラ層のアダプター、純粋なユーティリティ                          | Prisma アダプター、ロガー  |
+| `modules/` | Repository を使う共通処理、複数ドメインから参照されるビジネスロジック | ユーザー認証、権限チェック |
+
+### shared/
+
+`shared/` にはドメインに依存しない純粋なインフラ層を配置します。
+
+```
+shared/
+├── adapters/
+│   └── prisma/
+│       └── prisma.adapter.ts
+├── utils/
+│   └── id-generator.ts
+└── index.ts
+```
+
+### modules/
+
+`shared/` では共通化が難しい **Repository を使うような処理**（例：ユーザー認証、アクセス制御など）は、`modules/` に配置します。
+
+```
+modules/
+└── auth/
+    ├── auth.module.ts
+    ├── auth.service.ts
+    ├── auth.guard.ts
+    └── repositories/
+        └── auth.repository.ts
+```
+
+### 依存関係のルール
+
+```
+domains/ ──参照可→ modules/ ──参照可→ shared/
+    │                 │
+    └──参照可─────────┘
+
+※ 逆方向の参照は禁止
+```
+
+このルールは `eslint-plugin-boundaries` で自動チェックされます（前章参照）。
+
+## Clean Architecture + CQRS
+
+NestJS の `@nestjs/cqrs` パッケージを使用し、コマンド（書き込み）とクエリ（読み取り）を分離しています。
+
+### CQRS とは
+
+**Command Query Responsibility Segregation**（コマンドクエリ責務分離）の略で、読み取りと書き込みの処理を分離するパターンです。
+
+| 種別    | 役割         | 例                   |
+| ------- | ------------ | -------------------- |
+| Query   | 読み取り専用 | ユーザー情報の取得   |
+| Command | 書き込み処理 | ユーザーの作成・更新 |
+
+### ディレクトリ構成
+
+```
+src/
+├── main.ts                 # エントリーポイント
+├── app.module.ts           # ルートモジュール
+├── domains/                # ドメイン層（Vertical Slice）
+│   └── user/
+│       ├── dto/            # データ転送オブジェクト
+│       ├── queries/        # CQRS クエリハンドラー
+│       ├── commands/       # CQRS コマンドハンドラー（必要に応じて）
+│       ├── repositories/   # リポジトリ（データアクセス抽象化）
+│       ├── services/       # ドメインサービス
+│       ├── user.controller.ts
+│       └── user.module.ts
+├── modules/                # 共通モジュール
+│   └── auth/
+│       ├── auth.module.ts
+│       ├── auth.service.ts
+│       └── auth.guard.ts
+└── shared/                 # 共有コンポーネント
+    └── adapters/
+        └── prisma/
+```
+
+### Query の例
+
+```typescript
+// domains/user/queries/get-user/get-user.query.ts
+export class GetUserQuery {
+  constructor(public readonly userId: number) {}
+}
+
+// domains/user/queries/get-user/get-user.handler.ts
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetUserQuery } from './get-user.query';
+import { UserRepository } from '../../repositories/user.repository';
+
+@QueryHandler(GetUserQuery)
+export class GetUserHandler implements IQueryHandler<GetUserQuery> {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(query: GetUserQuery) {
+    return this.userRepository.getUserById(query.userId);
+  }
+}
+```
+
+### Controller から Query を実行
+
+```typescript
+// domains/user/user.controller.ts
+import { Controller, Get, Param } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { GetUserQuery } from './queries/get-user/get-user.query';
+
+@Controller('users')
+export class UserController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @Get(':id')
+  async getUser(@Param('id') id: string) {
+    return this.queryBus.execute(new GetUserQuery(Number(id)));
+  }
+}
+```
+
+## 新しいドメインの追加方法
+
+新しいドメイン（例: `product`）を追加する場合の手順です。
+
+### 1. ディレクトリ構造を作成
+
+```
+src/domains/product/
+├── dto/
+│   └── get-product.dto.ts
+├── queries/
+│   └── get-product/
+│       ├── get-product.query.ts
+│       └── get-product.handler.ts
+├── repositories/
+│   └── product.repository.ts
+├── services/
+│   └── product.service.ts
+├── product.controller.ts
+└── product.module.ts
+```
+
+### 2. モジュールを定義
+
+```typescript
+// domains/product/product.module.ts
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { ProductController } from './product.controller';
+import { ProductRepository } from './repositories/product.repository';
+import { GetProductHandler } from './queries/get-product/get-product.handler';
+
+const queryHandlers = [GetProductHandler];
+
+@Module({
+  imports: [CqrsModule],
+  controllers: [ProductController],
+  providers: [ProductRepository, ...queryHandlers],
+})
+export class ProductModule {}
+```
+
+### 3. ルートモジュールに追加
+
+```typescript
+// app.module.ts
+import { Module } from '@nestjs/common';
+import { UserModule } from './domains/user/user.module';
+import { ProductModule } from './domains/product/product.module';
+
+@Module({
+  imports: [UserModule, ProductModule],
+})
+export class AppModule {}
+```
+
+## まとめ
+
+このアーキテクチャ設計により、以下を実現しています。
+
+1. **Vertical Slice Architecture** - 機能ごとの独立性と高い凝集度
+2. **shared / modules の分離** - 依存関係の明確化
+3. **eslint-plugin-boundaries** - アーキテクチャルールの自動検証
+4. **CQRS パターン** - 読み取りと書き込みの責務分離
+5. **スケーラビリティ** - チーム分割やマイクロサービス化への対応
+
+これらの設計方針により、プロジェクトが成長しても保守しやすいコードベースを維持できます。


### PR DESCRIPTION
## 概要

develop ブランチの変更を main にマージします。

## 含まれる変更

### NestJS + esbuild + Vitest 高速開発環境ガイド記事

Prisma 7.x の ESModule 標準化で NestJS ビルドに困っている方向けの記事シリーズを追加しました。

**記事構成:**
1. 概要
2. Prisma ESModule 化の課題
3. esbuild + SWC ビルドシステム
4. Vitest + SWC テスト環境
5. TypeScript / ESLint 設定
6. アーキテクチャ設計（Vertical Slice + CQRS）