### PR TITLE
feat(content): add Angular 21 + NGXS article series

### DIFF
--- a/apps/content/articles/04-turbo-pnpm/01-overview.md
+++ b/apps/content/articles/04-turbo-pnpm/01-overview.md
@@ -5,7 +5,7 @@ description: Turborepo + pnpm を使用したモダンなモノレポテンプ�
 
 本シリーズでは、**Turborepo + pnpm** を使用したモダンなモノレポのテンプレートを解説します。
 
-テンプレートリポジトリ: [GitHub - turbo-pnpm](https://github.com/your-username/turbo-pnpm)
+テンプレートリポジトリ: [GitHub - turbo-pnpm](https://github.com/motora-dev/turbo-pnpm)
 
 ## 特徴
 

--- a/apps/content/articles/05-nestjs-esbuild-vitest/01-overview.md
+++ b/apps/content/articles/05-nestjs-esbuild-vitest/01-overview.md
@@ -5,7 +5,7 @@ description: NestJS + esbuild + Vitest を使用した高速開発環境テン�
 
 本シリーズでは、**NestJS + esbuild + Vitest** を使用した高速開発環境のモノレポテンプレートを解説します。
 
-テンプレートリポジトリ: [GitHub - nestjs-esbuild-vitest](https://github.com/your-username/nestjs-esbuild-vitest)
+テンプレートリポジトリ: [GitHub - nestjs-esbuild-vitest](https://github.com/motora-dev/nestjs-esbuild-vitest)
 
 ## こんな方へ
 
@@ -21,15 +21,15 @@ Prisma 7.x 以降の ESModule 標準化により、従来の NestJS ビルド環
 
 このテンプレートは、以下の特徴を持つモダンな開発環境を提供します。
 
-| 機能                    | 説明                                         |
-| ----------------------- | -------------------------------------------- |
-| **esbuild + SWC**       | NestJS のデコレーターに対応した超高速ビルド  |
-| **Vitest**              | SWC を使った高速なユニット/E2E テスト        |
-| **Prisma**              | ESModule 対応の型安全な ORM                  |
-| **Turborepo**           | 高速なビルドシステムとキャッシング           |
-| **pnpm Catalogs**       | 依存関係のバージョンを一元管理               |
-| **ESLint Flat Config**  | 最新の ESLint 設定形式 + アーキテクチャ検証  |
-| **GitHub Actions CI**   | 自動テスト・ビルド                           |
+| 機能                   | 説明                                        |
+| ---------------------- | ------------------------------------------- |
+| **esbuild + SWC**      | NestJS のデコレーターに対応した超高速ビルド |
+| **Vitest**             | SWC を使った高速なユニット/E2E テスト       |
+| **Prisma**             | ESModule 対応の型安全な ORM                 |
+| **Turborepo**          | 高速なビルドシステムとキャッシング          |
+| **pnpm Catalogs**      | 依存関係のバージョンを一元管理              |
+| **ESLint Flat Config** | 最新の ESLint 設定形式 + アーキテクチャ検証 |
+| **GitHub Actions CI**  | 自動テスト・ビルド                          |
 
 ## 開発体験の改善
 
@@ -94,4 +94,3 @@ pnpm check-all
 3. **Vitest + SWC テスト環境** - 高速なテスト環境の構築
 4. **TypeScript / ESLint 設定** - モダンな設定ファイルの解説
 5. **アーキテクチャ設計** - Vertical Slice Architecture と CQRS
-

--- a/apps/content/articles/06-angular-ngxs/00-metadata.json
+++ b/apps/content/articles/06-angular-ngxs/00-metadata.json
@@ -1,0 +1,38 @@
+{
+  "title": "Angular 21 + NGXS モダンフロントエンド開発ガイド",
+  "description": "Angular 21のZoneless変更検知、NGXSによる状態管理、shadcn/uiスタイルのUIコンポーネント、Storybook、RxAngular + ISRまで、モダンなAngular開発環境を構築するテンプレートを解説します。",
+  "tags": ["Angular", "NGXS", "RxAngular", "Tailwind CSS"],
+  "status": "PUBLIC",
+  "pages": [
+    {
+      "file": "01-overview.md",
+      "level": 1,
+      "order": 1
+    },
+    {
+      "file": "02-zoneless-angular.md",
+      "level": 1,
+      "order": 2
+    },
+    {
+      "file": "03-ngxs-facade.md",
+      "level": 1,
+      "order": 3
+    },
+    {
+      "file": "04-ui-storybook.md",
+      "level": 1,
+      "order": 4
+    },
+    {
+      "file": "05-rxangular-ssr.md",
+      "level": 1,
+      "order": 5
+    },
+    {
+      "file": "06-architecture.md",
+      "level": 1,
+      "order": 6
+    }
+  ]
+}

--- a/apps/content/articles/06-angular-ngxs/01-overview.md
+++ b/apps/content/articles/06-angular-ngxs/01-overview.md
@@ -1,0 +1,137 @@
+---
+title: 概要
+description: Angular 21 + NGXS + RxAngular を使用したモダンフロントエンド開発テンプレートの特徴と、プロジェクト構成を解説します。
+---
+
+本シリーズでは、**Angular 21 + NGXS + RxAngular** を使用したモダンフロントエンド開発のモノレポテンプレートを解説します。
+
+テンプレートリポジトリ: [GitHub - angular-ngxs](https://github.com/motora-dev/angular-ngxs)
+
+## こんな方へ
+
+Angular でモダンな開発環境を構築したい方向けのテンプレートです。
+
+- **Zone.js に依存しない** 高性能な変更検知を実現したい
+- **Redux ライクな状態管理** を TypeScript のデコレーターで直感的に実装したい
+- **shadcn/ui のような** 柔軟にカスタマイズ可能な UI コンポーネント構成にしたい
+- **SSR + ISR** でパフォーマンスと SEO を両立したい
+
+これらの課題を **Angular 21 + NGXS + RxAngular** で解決します。
+
+## 特徴
+
+このテンプレートは、以下の特徴を持つモダンな開発環境を提供します。
+
+| 機能                    | 説明                                   |
+| ----------------------- | -------------------------------------- |
+| **Angular 21 Zoneless** | Zone.js 不要の高性能な変更検知         |
+| **NGXS**                | デコレーターベースのシンプルな状態管理 |
+| **Angular ARIA/CDK**    | アクセシビリティ対応コンポーネント     |
+| **Tailwind CSS 4**      | ユーティリティファースト CSS           |
+| **RxAngular**           | 高性能リアクティブユーティリティ + ISR |
+| **Storybook**           | UI コンポーネントカタログ              |
+| **Vitest**              | 高速なユニットテスト                   |
+
+## 技術スタック
+
+| カテゴリ         | 技術                                      |
+| ---------------- | ----------------------------------------- |
+| Framework        | Angular 21 (Zoneless)                     |
+| Build            | Vite (via @angular/build)                 |
+| State Management | NGXS + @ngxs/form-plugin                  |
+| Forms            | Reactive Forms + Validators               |
+| UI Components    | shadcn/ui アプローチ（Angular CDK + cva） |
+| Styling          | Tailwind CSS 4                            |
+| Accessibility    | @angular/cdk/a11y, @angular/aria          |
+| Reactive         | @rx-angular/template, @rx-angular/isr     |
+| SSR              | Angular SSR + ISR                         |
+| UI Catalog       | Storybook 10                              |
+| Testing          | Vitest + @testing-library/angular         |
+
+## 開発体験の改善
+
+従来の開発環境と比較して、ビルドとテストが劇的に高速化されています。
+
+| 項目           | 従来（tsc + Jest） | 現在（Vite + Vitest） | 改善率       |
+| -------------- | ------------------ | --------------------- | ------------ |
+| ビルド         | 20〜30 秒          | **数秒**              | 約 10〜20 倍 |
+| テスト起動     | 5〜10 秒           | **500 ミリ秒〜1 秒**  | 約 10〜20 倍 |
+| ホットリロード | 遅い               | **高速**              | -            |
+
+## プロジェクト構成
+
+```
+angular-ngxs/
+├── apps/
+│   ├── client/             # Angular クライアント (SSR対応)
+│   └── server/             # NestJS サーバー
+├── packages/
+│   ├── database/           # Prisma データベース設定
+│   ├── eslint-config/      # 共有 ESLint 設定
+│   └── typescript-config/  # 共有 TypeScript 設定
+├── turbo.json              # Turborepo 設定
+└── pnpm-workspace.yaml     # pnpm ワークスペース設定
+```
+
+### クライアント（Angular）のディレクトリ構成
+
+```
+src/
+├── app/              # ルートコンポーネント + 各ページ
+│   ├── app.ts            # ルートコンポーネント
+│   ├── app.config.ts     # アプリケーション設定
+│   ├── app.routes.ts     # ルーティング定義
+│   └── {page}/           # 各ページ（Vertical Slice）
+├── components/       # 複数ページで共有するコンポーネント
+├── domains/          # ドメインロジック + 状態管理（NGXS）
+├── modules/          # 機能モジュール（将来拡張用）
+└── shared/           # 共有リソース
+    ├── lib/              # ユーティリティ関数
+    └── ui/               # UIプリミティブ（shadcn/ui相当）
+```
+
+## セットアップ
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/motora-dev/angular-ngxs.git
+cd angular-ngxs
+
+# 依存関係をインストール
+pnpm install
+
+# すべてのチェックを実行
+pnpm check-all
+```
+
+## コマンド一覧
+
+| コマンド             | 説明                            |
+| -------------------- | ------------------------------- |
+| `pnpm build`         | すべてのパッケージをビルド      |
+| `pnpm start`         | 開発サーバーを起動              |
+| `pnpm check-all`     | lint, format, tsc, test を実行  |
+| `pnpm lint`          | ESLint を実行                   |
+| `pnpm format`        | Prettier でフォーマットチェック |
+| `pnpm tsc`           | TypeScript 型チェック           |
+| `pnpm test`          | テストを実行                    |
+| `pnpm test:coverage` | カバレッジ付きテスト            |
+
+### クライアント固有コマンド
+
+| コマンド                                          | 説明                         |
+| ------------------------------------------------- | ---------------------------- |
+| `pnpm --filter @monorepo/client storybook`        | Storybook を起動             |
+| `pnpm --filter @monorepo/client build-storybook`  | Storybook をビルド           |
+| `pnpm --filter @monorepo/client serve:ssr:client` | SSR サーバーを起動           |
+| `pnpm --filter @monorepo/client test:watch`       | テストをウォッチモードで実行 |
+
+## 次のステップ
+
+以降のページでは、各機能について詳しく解説します。
+
+1. **Angular 21 Zoneless 変更検知** - Zone.js 不要の高性能な変更検知
+2. **NGXS 状態管理 + Facade パターン** - シンプルで型安全な状態管理
+3. **shadcn/ui スタイル UI + Storybook** - 柔軟な UI コンポーネント構成
+4. **RxAngular + SSR/ISR** - 高性能リアクティブ処理と ISR
+5. **アーキテクチャ設計** - Vertical Slice Architecture

--- a/apps/content/articles/06-angular-ngxs/02-zoneless-angular.md
+++ b/apps/content/articles/06-angular-ngxs/02-zoneless-angular.md
@@ -1,0 +1,265 @@
+---
+title: Angular 21 Zoneless 変更検知
+description: Angular 21で導入されたZoneless変更検知の仕組みと、Signalを活用した高性能な状態管理について解説します。
+---
+
+## Zoneless 変更検知とは
+
+Angular 21 では、従来の Zone.js に依存しない **Zoneless 変更検知** が正式にサポートされました。これにより、パフォーマンスの向上と予測可能な動作を実現できます。
+
+### Zone.js の問題点
+
+従来の Angular は Zone.js を使用して変更検知をトリガーしていました。
+
+```typescript
+// Zone.js による自動検知
+onClick() {
+  this.count++;  // Zone.js がこの変更を検知
+}
+```
+
+しかし、Zone.js には以下の問題がありました：
+
+| 問題点           | 説明                                               |
+| ---------------- | -------------------------------------------------- |
+| パフォーマンス   | すべての非同期処理をラップするオーバーヘッド       |
+| 予測困難         | いつ変更検知が走るか予測しにくい                   |
+| サードパーティ   | Zone.js 非対応のライブラリとの互換性問題           |
+| デバッグ         | スタックトレースが複雑になる                       |
+
+### Zoneless の利点
+
+Zoneless 変更検知では、Signal や Observable の変更を明示的に検知します。
+
+| 利点             | 説明                                               |
+| ---------------- | -------------------------------------------------- |
+| 高パフォーマンス | 不要な変更検知が発生しない                         |
+| 予測可能         | 変更検知のタイミングが明確                         |
+| 軽量             | Zone.js のバンドルサイズを削減                     |
+| 互換性           | すべての JavaScript ライブラリと互換性がある       |
+
+## 設定方法
+
+### provideZonelessChangeDetection
+
+`app.config.ts` で `provideZonelessChangeDetection()` を設定します。
+
+```typescript
+import {
+  ApplicationConfig,
+  isDevMode,
+  provideBrowserGlobalErrorListeners,
+  provideZonelessChangeDetection,
+} from '@angular/core';
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { withNgxsReduxDevtoolsPlugin } from '@ngxs/devtools-plugin';
+import { withNgxsFormPlugin } from '@ngxs/form-plugin';
+import { provideStore } from '@ngxs/store';
+
+import { APP_STATES } from '$domains';
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideClientHydration(withEventReplay()),
+    provideRouter(routes),
+    provideStore(APP_STATES, withNgxsFormPlugin(), withNgxsReduxDevtoolsPlugin({ disabled: !isDevMode() })),
+    provideZonelessChangeDetection(),  // ← Zoneless を有効化
+  ],
+};
+```
+
+### polyfills から Zone.js を削除
+
+`angular.json` の polyfills から `zone.js` を削除します。
+
+```json
+{
+  "projects": {
+    "client": {
+      "architect": {
+        "build": {
+          "options": {
+            "polyfills": []  // zone.js を含めない
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Signal による状態管理
+
+Zoneless 環境では、**Signal** を使用してコンポーネントのローカル状態を管理します。
+
+### 基本的な Signal の使用
+
+```typescript
+import { Component, signal, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-counter',
+  template: `
+    <p>Count: {{ count() }}</p>
+    <p>Double: {{ double() }}</p>
+    <button (click)="increment()">+1</button>
+  `,
+})
+export class CounterComponent {
+  // signal() で状態を定義
+  readonly count = signal(0);
+
+  // computed() で派生状態を定義
+  readonly double = computed(() => this.count() * 2);
+
+  increment(): void {
+    // update() で状態を更新
+    this.count.update(v => v + 1);
+  }
+}
+```
+
+### Signal の API
+
+| API             | 用途                         | 例                              |
+| --------------- | ---------------------------- | ------------------------------- |
+| `signal()`      | 状態の作成                   | `signal(0)`                     |
+| `computed()`    | 派生状態の作成               | `computed(() => count() * 2)`   |
+| `effect()`      | 副作用の実行                 | `effect(() => console.log(x()))`|
+| `.set()`        | 値を直接設定                 | `count.set(10)`                 |
+| `.update()`     | 現在値を元に更新             | `count.update(v => v + 1)`      |
+
+## input() / output() シグナル
+
+Angular 21 では、`@Input()` / `@Output()` デコレーターの代わりに Signal ベースの API を使用できます。
+
+### input() シグナル
+
+```typescript
+import { Component, input, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-greeting',
+  template: `<p>{{ greeting() }}</p>`,
+})
+export class GreetingComponent {
+  // input() で入力プロパティを定義
+  readonly name = input<string>('Guest');
+  readonly title = input.required<string>();  // 必須の入力
+
+  // computed() で派生値を計算
+  readonly greeting = computed(() => `${this.title()}, ${this.name()}!`);
+}
+```
+
+```html
+<!-- 使用例 -->
+<app-greeting title="Hello" name="Angular" />
+```
+
+### output() シグナル
+
+```typescript
+import { Component, output } from '@angular/core';
+
+@Component({
+  selector: 'app-button',
+  template: `<button (click)="handleClick()">Click me</button>`,
+})
+export class ButtonComponent {
+  // output() でイベントを定義
+  readonly clicked = output<void>();
+
+  handleClick(): void {
+    this.clicked.emit();
+  }
+}
+```
+
+## Zoneless と RxJS の組み合わせ
+
+Zoneless 環境では、Observable の変更が自動的に検知されません。そのため、**RxAngular** の `*rxLet` ディレクティブを使用します。
+
+### 問題: async パイプでは変更検知されない
+
+```typescript
+// ❌ Zoneless 環境では動作しない
+@Component({
+  template: `<p>{{ count$ | async }}</p>`,
+})
+export class BadComponent {
+  count$ = this.store.select(state => state.count);
+}
+```
+
+### 解決策: *rxLet ディレクティブ
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { RxLet } from '@rx-angular/template/let';
+
+@Component({
+  imports: [RxLet],
+  template: `
+    <div *rxLet="count$; let count">
+      {{ count }}
+    </div>
+  `,
+})
+export class GoodComponent {
+  private readonly facade = inject(HomeFacade);
+  readonly count$ = this.facade.count$;
+}
+```
+
+`*rxLet` は Observable の値が変更されたときに適切に変更検知をトリガーします。
+
+## リアクティブパターンの使い分け
+
+Zoneless 環境では、状態のスコープに応じて適切なパターンを選択します。
+
+| スコープ       | 技術                             | 用途                       |
+| -------------- | -------------------------------- | -------------------------- |
+| ローカル状態   | **Signal**                       | コンポーネント内部         |
+| グローバル状態 | **NGXS + `*rxLet`**              | domains 連携、大規模データ |
+| フォーム       | **Reactive Forms + form-plugin** | バリデーション + Store 同期|
+
+### 使い分けの指針
+
+```typescript
+@Component({
+  template: `
+    <!-- ローカル状態は Signal -->
+    <p>Local: {{ localCount() }}</p>
+
+    <!-- グローバル状態は *rxLet -->
+    <div *rxLet="globalCount$; let count">
+      Global: {{ count }}
+    </div>
+  `,
+})
+export class ExampleComponent {
+  // ローカル状態
+  readonly localCount = signal(0);
+
+  // グローバル状態（NGXS Store）
+  private readonly facade = inject(HomeFacade);
+  readonly globalCount$ = this.facade.count$;
+}
+```
+
+## まとめ
+
+Angular 21 の Zoneless 変更検知により、以下を実現できます。
+
+1. **パフォーマンス向上** - 不要な変更検知を排除
+2. **予測可能な動作** - 変更検知のタイミングが明確
+3. **Signal による状態管理** - 直感的で型安全な API
+4. **RxAngular との統合** - Observable を効率的に描画
+
+次のページでは、NGXS を使用したグローバルな状態管理と Facade パターンについて解説します。
+
+

--- a/apps/content/articles/06-angular-ngxs/03-ngxs-facade.md
+++ b/apps/content/articles/06-angular-ngxs/03-ngxs-facade.md
@@ -1,0 +1,346 @@
+---
+title: NGXS 状態管理 + Facade パターン
+description: NGXSによるシンプルで型安全な状態管理と、Facadeパターンによるコンポーネントとの疎結合化、@ngxs/form-pluginによるフォーム連携を解説します。
+---
+
+## NGXS とは
+
+**NGXS** は、Angular 向けの状態管理ライブラリです。Redux パターンをシンプルに実装でき、TypeScript のデコレーターを活用した直感的な API を提供します。
+
+### Redux との比較
+
+| 項目           | Redux (NgRx)                | NGXS                          |
+| -------------- | --------------------------- | ----------------------------- |
+| ボイラープレート| 多い                        | **少ない**                    |
+| 学習コスト     | 高い                        | **低い**                      |
+| TypeScript     | 設定が必要                  | **ネイティブサポート**        |
+| デコレーター   | 使用しない                  | **活用**                      |
+| テスタビリティ | 高い                        | 高い                          |
+
+## ディレクトリ構成
+
+NGXS の状態管理は `domains/` 配下に配置します。
+
+```
+domains/{domain}/
+├── store/
+│   ├── {domain}.state.ts    # State 定義 + Selector
+│   └── {domain}.actions.ts  # Action 定義
+├── {domain}.facade.ts       # Store アクセスの抽象化
+└── index.ts                 # エクスポート
+```
+
+## State の定義
+
+State クラスでは、状態のモデルと初期値、Selector、Action ハンドラーを定義します。
+
+### 基本的な State
+
+```typescript
+// domains/home/store/home.state.ts
+import { Injectable } from '@angular/core';
+import { Action, Selector, State, StateContext } from '@ngxs/store';
+
+import { Increment } from './home.actions';
+
+/** Form model for text input */
+export interface TextFormModel {
+  text: string;
+}
+
+/** NGXS form plugin metadata */
+export interface TextFormState {
+  model: TextFormModel;
+  dirty: boolean;
+  status: string;
+  errors: Record<string, unknown>;
+}
+
+export interface HomeStateModel {
+  count: number;
+  textForm: TextFormState;
+}
+
+@State<HomeStateModel>({
+  name: 'home',
+  defaults: {
+    count: 0,
+    textForm: {
+      model: { text: '' },
+      dirty: false,
+      status: '',
+      errors: {},
+    },
+  },
+})
+@Injectable()
+export class HomeState {
+  @Selector()
+  static getCount(state: HomeStateModel): number {
+    return state.count;
+  }
+
+  @Selector()
+  static getTextFormModel(state: HomeStateModel): TextFormModel {
+    return state.textForm.model;
+  }
+
+  @Selector()
+  static getTextFormStatus(state: HomeStateModel): string {
+    return state.textForm.status;
+  }
+
+  @Selector()
+  static getTextFormDirty(state: HomeStateModel): boolean {
+    return state.textForm.dirty;
+  }
+
+  @Action(Increment)
+  increment(ctx: StateContext<HomeStateModel>): void {
+    const state = ctx.getState();
+    ctx.patchState({
+      count: state.count + 1,
+    });
+  }
+}
+```
+
+### ポイント解説
+
+| デコレーター | 役割                               |
+| ------------ | ---------------------------------- |
+| `@State`     | 状態の名前と初期値を定義           |
+| `@Selector`  | 状態から値を取得する関数を定義     |
+| `@Action`    | Action がディスパッチされたときの処理を定義 |
+
+## Action の定義
+
+Action は、状態変更のトリガーとなるクラスです。
+
+```typescript
+// domains/home/store/home.actions.ts
+export class Increment {
+  static readonly type = '[Home] Increment';
+}
+
+export class SetCount {
+  static readonly type = '[Home] Set Count';
+  constructor(public readonly count: number) {}
+}
+
+export class LoadData {
+  static readonly type = '[Home] Load Data';
+}
+```
+
+### Action の命名規則
+
+```typescript
+// [ドメイン名] 操作名
+static readonly type = '[Home] Increment';
+static readonly type = '[User] Load Profile';
+static readonly type = '[Cart] Add Item';
+```
+
+## Facade パターン
+
+**Facade パターン** を使用して、Store へのアクセスを抽象化します。これにより、コンポーネントと Store の結合度を下げられます。
+
+### Facade の実装
+
+```typescript
+// domains/home/home.facade.ts
+import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngxs/store';
+import { Observable } from 'rxjs';
+
+import { Increment } from './store/home.actions';
+import { HomeState, type TextFormModel } from './store/home.state';
+
+/**
+ * Facade service for Home domain
+ * Abstracts store access and provides a clean API for components
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class HomeFacade {
+  private readonly store = inject(Store);
+
+  /** Observable of the current count */
+  readonly count$: Observable<number> = this.store.select(HomeState.getCount);
+
+  /** Observable of the text form model */
+  readonly textFormModel$: Observable<TextFormModel> = this.store.select(HomeState.getTextFormModel);
+
+  /** Observable of the text form status (VALID, INVALID, etc.) */
+  readonly textFormStatus$: Observable<string> = this.store.select(HomeState.getTextFormStatus);
+
+  /** Observable of the text form dirty state */
+  readonly textFormDirty$: Observable<boolean> = this.store.select(HomeState.getTextFormDirty);
+
+  /** Increment the counter */
+  increment(): void {
+    this.store.dispatch(new Increment());
+  }
+}
+```
+
+### Facade の利点
+
+| 利点               | 説明                                         |
+| ------------------ | -------------------------------------------- |
+| 疎結合             | コンポーネントが Store の詳細を知らなくてよい |
+| テスタビリティ     | Facade をモックするだけでテスト可能          |
+| リファクタリング   | Store の内部実装を変更しても影響が少ない     |
+| 型安全             | TypeScript の型推論が効く                    |
+
+### コンポーネントからの使用
+
+```typescript
+// app/home/home.ts
+import { Component, inject } from '@angular/core';
+import { RxLet } from '@rx-angular/template/let';
+
+import { HomeFacade } from '$domains/home';
+import { ButtonDirective } from '$shared/ui/button';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [RxLet, ButtonDirective],
+  template: `
+    <div *rxLet="count$; let count">
+      <p>Count: {{ count }}</p>
+      <button appButton (click)="increment()">+1</button>
+    </div>
+  `,
+})
+export class HomeComponent {
+  private readonly facade = inject(HomeFacade);
+
+  readonly count$ = this.facade.count$;
+
+  increment(): void {
+    this.facade.increment();
+  }
+}
+```
+
+## フォーム連携（@ngxs/form-plugin）
+
+**@ngxs/form-plugin** を使用すると、Reactive Forms と NGXS Store を自動同期できます。
+
+### 設定
+
+```typescript
+// app.config.ts
+import { withNgxsFormPlugin } from '@ngxs/form-plugin';
+import { provideStore } from '@ngxs/store';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideStore(APP_STATES, withNgxsFormPlugin()),
+  ],
+};
+```
+
+### State にフォーム状態を追加
+
+```typescript
+// 状態モデル
+export interface HomeStateModel {
+  count: number;
+  textForm: TextFormState;  // フォーム状態
+}
+
+// 初期値
+@State<HomeStateModel>({
+  name: 'home',
+  defaults: {
+    count: 0,
+    textForm: {
+      model: { text: '' },
+      dirty: false,
+      status: '',
+      errors: {},
+    },
+  },
+})
+```
+
+### テンプレートでの使用
+
+```html
+<!-- ngxsForm でフォームと Store を紐付け -->
+<form [formGroup]="textForm" ngxsForm="home.textForm">
+  <app-input-field
+    label="テキスト"
+    [control]="textForm.controls.text"
+  >
+    <input appInput formControlName="text" />
+  </app-input-field>
+</form>
+```
+
+### フォーム状態の自動同期
+
+`ngxsForm="home.textForm"` を指定すると、以下が自動的に同期されます：
+
+| プロパティ | 説明                           |
+| ---------- | ------------------------------ |
+| `model`    | フォームの値                   |
+| `dirty`    | 値が変更されたか               |
+| `status`   | バリデーション状態（VALID 等） |
+| `errors`   | バリデーションエラー           |
+
+## Store の登録
+
+State を `app.config.ts` で登録します。
+
+```typescript
+// domains/index.ts
+import { HomeState } from './home/store/home.state';
+
+export const APP_STATES = [HomeState];
+
+// app.config.ts
+import { APP_STATES } from '$domains';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideStore(APP_STATES, withNgxsFormPlugin()),
+  ],
+};
+```
+
+## DevTools との連携
+
+開発時には Redux DevTools で状態を確認できます。
+
+```typescript
+import { withNgxsReduxDevtoolsPlugin } from '@ngxs/devtools-plugin';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideStore(
+      APP_STATES,
+      withNgxsFormPlugin(),
+      withNgxsReduxDevtoolsPlugin({ disabled: !isDevMode() })
+    ),
+  ],
+};
+```
+
+## まとめ
+
+NGXS + Facade パターンにより、以下を実現できます。
+
+1. **シンプルな状態管理** - デコレーターベースの直感的な API
+2. **Facade による疎結合** - コンポーネントと Store の分離
+3. **フォーム連携** - Reactive Forms と Store の自動同期
+4. **型安全** - TypeScript のフルサポート
+
+次のページでは、shadcn/ui スタイルの UI コンポーネント構成と Storybook について解説します。
+
+

--- a/apps/content/articles/06-angular-ngxs/04-ui-storybook.md
+++ b/apps/content/articles/06-angular-ngxs/04-ui-storybook.md
@@ -1,0 +1,443 @@
+---
+title: shadcn/ui スタイル UI + Storybook
+description: CVA + Angular CDKを使用したshadcn/uiスタイルのUIコンポーネント構成と、StorybookによるUIカタログの作成方法を解説します。
+---
+
+## shadcn/ui アプローチとは
+
+**shadcn/ui** は、React 向けの UI コンポーネントライブラリですが、そのアプローチは Angular にも適用できます。
+
+### 特徴
+
+| 特徴           | 説明                                           |
+| -------------- | ---------------------------------------------- |
+| コピー可能     | npm パッケージではなく、コードをコピーして使用 |
+| カスタマイズ性 | 自由に変更可能                                 |
+| Tailwind CSS   | ユーティリティクラスでスタイリング             |
+| CVA            | バリアント管理を型安全に                       |
+
+このテンプレートでは、Angular 向けに shadcn/ui のアプローチを採用しています。
+
+## Primitives vs Composed
+
+UI コンポーネントを 2 層に分けて管理します。
+
+| 種類           | 配置先        | 責務                       | パッケージ化 |
+| -------------- | ------------- | -------------------------- | ------------ |
+| **Primitives** | `shared/ui/`  | スタイリングのみ、状態なし | 可能         |
+| **Composed**   | `components/` | ロジック連携、状態あり     | このリポジトリ固有 |
+
+### Primitives（shared/ui/）
+
+最小単位の UI コンポーネント。外部パッケージ化も可能です。
+
+- `ButtonDirective` - ボタンスタイル
+- `InputDirective` - 入力フィールドスタイル
+
+### Composed（components/）
+
+Primitives を組み合わせ、ロジックを含むコンポーネント。
+
+- `InputFieldComponent` - Reactive Forms 連携、エラー表示
+
+## CVA（Class Variance Authority）
+
+**CVA** は、バリアント（variant）を型安全に管理するライブラリです。
+
+### インストール
+
+```bash
+pnpm add class-variance-authority
+```
+
+### Button コンポーネントの実装
+
+```typescript
+// shared/ui/button/button.ts
+import { FocusMonitor } from '@angular/cdk/a11y';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  ElementRef,
+  effect,
+  DestroyRef,
+} from '@angular/core';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+/**
+ * Button variants definition (shadcn/ui pattern)
+ */
+export const buttonVariants = cva(
+  // Base styles
+  `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium
+   transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring
+   disabled:pointer-events-none disabled:opacity-50
+   [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0`,
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>;
+
+/**
+ * Button component (shadcn/ui style for Angular)
+ */
+@Component({
+  selector: 'button[appButton], a[appButton]',
+  standalone: true,
+  template: `<ng-content />`,
+  host: {
+    '[class]': 'computedClass()',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ButtonDirective {
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly focusMonitor = inject(FocusMonitor);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Button variant */
+  readonly variant = input<ButtonVariants['variant']>('default');
+
+  /** Button size */
+  readonly size = input<ButtonVariants['size']>('default');
+
+  /** Additional CSS classes */
+  readonly class = input<string>('');
+
+  /** Computed class combining variants and custom classes */
+  readonly computedClass = computed(() =>
+    cn(
+      buttonVariants({
+        variant: this.variant(),
+        size: this.size(),
+      }),
+      this.class(),
+    ),
+  );
+
+  constructor() {
+    // Setup focus monitoring for a11y
+    effect(() => {
+      this.focusMonitor.monitor(this.elementRef, true);
+    });
+
+    // Cleanup on destroy
+    this.destroyRef.onDestroy(() => {
+      this.focusMonitor.stopMonitoring(this.elementRef);
+    });
+  }
+}
+```
+
+### 使用例
+
+```html
+<button appButton>Default</button>
+<button appButton variant="destructive">Delete</button>
+<button appButton variant="outline" size="sm">Small</button>
+<button appButton variant="ghost" size="icon">
+  <svg>...</svg>
+</button>
+```
+
+## cn() ユーティリティ
+
+**cn()** は、Tailwind CSS クラスを安全にマージするユーティリティです。
+
+```typescript
+// shared/lib/utils.ts
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Tailwind CSS クラスを安全にマージするユーティリティ
+ * shadcn/ui と同じパターン（clsx + tailwind-merge）
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}
+```
+
+### なぜ cn() が必要か
+
+```typescript
+// 通常の文字列結合では競合が発生
+'px-4 px-8'  // 両方適用される問題
+
+// cn() を使うと後勝ち
+cn('px-4', 'px-8')  // => 'px-8'
+
+// 条件付きクラスも簡潔に
+cn('base-class', condition && 'conditional-class')
+```
+
+## Angular CDK によるアクセシビリティ
+
+**@angular/cdk/a11y** を使用して、アクセシビリティを向上させます。
+
+### FocusMonitor
+
+キーボードフォーカスとマウスフォーカスを区別します。
+
+```typescript
+import { FocusMonitor } from '@angular/cdk/a11y';
+
+@Component({...})
+export class ButtonDirective {
+  private readonly focusMonitor = inject(FocusMonitor);
+  private readonly elementRef = inject(ElementRef);
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    effect(() => {
+      // フォーカスの監視を開始
+      this.focusMonitor.monitor(this.elementRef, true);
+    });
+
+    this.destroyRef.onDestroy(() => {
+      // クリーンアップ
+      this.focusMonitor.stopMonitoring(this.elementRef);
+    });
+  }
+}
+```
+
+## Composed コンポーネント
+
+Primitives を組み合わせて、ロジックを含むコンポーネントを作成します。
+
+### InputFieldComponent
+
+```typescript
+// components/input-field/input-field.ts
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { AbstractControl } from '@angular/forms';
+import { filter, merge, switchMap } from 'rxjs';
+
+/** Default error messages for common validators */
+const DEFAULT_ERROR_MESSAGES: Record<string, string> = {
+  required: '入力は必須です',
+  minlength: '文字数が足りません',
+  maxlength: '文字数が多すぎます',
+  email: 'メールアドレス形式で入力してください',
+  pattern: '入力形式が正しくありません',
+};
+
+/**
+ * InputFieldComponent - Composed component for form input with label and validation
+ */
+@Component({
+  selector: 'app-input-field',
+  standalone: true,
+  template: `
+    @if (label()) {
+      <label [for]="id()" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+        {{ label() }}
+      </label>
+    }
+
+    <ng-content></ng-content>
+
+    @if (showError()) {
+      <div class="mt-2 text-sm text-destructive">
+        @for (message of activeErrorMessages(); track message) {
+          <p>{{ message }}</p>
+        }
+      </div>
+    }
+  `,
+  host: {
+    class: 'block',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InputFieldComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Label text for the input */
+  readonly label = input<string>();
+
+  /** HTML id attribute for the input */
+  readonly id = input<string>();
+
+  /** Form control to monitor for validation state */
+  readonly control = input<AbstractControl>();
+
+  /** Custom error messages (merged with defaults) */
+  readonly messages = input<Record<string, string>>({});
+
+  /** Internal signal to track control state changes (for Zoneless compatibility) */
+  private readonly controlState = signal(0);
+
+  /** Whether to show error state */
+  readonly showError = computed(() => {
+    this.controlState();
+    const ctrl = this.control();
+    if (!ctrl) return false;
+    return ctrl.invalid && (ctrl.dirty || ctrl.touched);
+  });
+
+  /** Active error messages based on current validation errors */
+  readonly activeErrorMessages = computed(() => {
+    this.controlState();
+    const ctrl = this.control();
+    if (!ctrl?.errors) return [];
+
+    const msgs = { ...DEFAULT_ERROR_MESSAGES, ...this.messages() };
+    return Object.keys(ctrl.errors).map((key) => {
+      if (key === 'minlength') {
+        const error = ctrl.errors?.['minlength'];
+        return `${error.requiredLength}文字以上で入力してください`;
+      }
+      if (key === 'maxlength') {
+        const error = ctrl.errors?.['maxlength'];
+        return `${error.requiredLength}文字以内で入力してください`;
+      }
+      return msgs[key] ?? `${key} エラー`;
+    });
+  });
+
+  constructor() {
+    // Subscribe to control changes to update signal (Zoneless compatibility)
+    toObservable(this.control)
+      .pipe(
+        filter((ctrl): ctrl is AbstractControl => ctrl !== undefined),
+        switchMap((ctrl) => merge(ctrl.statusChanges, ctrl.events)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.controlState.update((v) => v + 1);
+      });
+  }
+}
+```
+
+### 使用例
+
+```html
+<app-input-field
+  label="ユーザー名"
+  [control]="form.controls.username"
+  [messages]="{ required: '必須項目です' }"
+>
+  <input appInput formControlName="username" />
+</app-input-field>
+```
+
+## Storybook
+
+**Storybook** を使用して、UI コンポーネントのカタログを作成します。
+
+### 起動
+
+```bash
+pnpm --filter @monorepo/client storybook  # http://localhost:6006
+```
+
+### Stories の作成
+
+```typescript
+// shared/ui/button/button.stories.ts
+import type { Meta, StoryObj } from '@storybook/angular';
+import { ButtonDirective, buttonVariants } from './button';
+
+const meta: Meta<ButtonDirective> = {
+  title: 'UI/Button',
+  component: ButtonDirective,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg', 'icon'],
+    },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<button appButton [variant]="variant" [size]="size">Button</button>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<ButtonDirective>;
+
+export const Default: Story = {
+  args: { variant: 'default', size: 'default' },
+};
+
+export const Destructive: Story = {
+  args: { variant: 'destructive' },
+};
+
+export const Outline: Story = {
+  args: { variant: 'outline' },
+};
+
+export const Small: Story = {
+  args: { size: 'sm' },
+};
+
+export const Large: Story = {
+  args: { size: 'lg' },
+};
+```
+
+### 対象コンポーネント
+
+| カテゴリ   | パス                      | 内容                |
+| ---------- | ------------------------- | ------------------- |
+| UI         | `shared/ui/button/`       | ButtonDirective     |
+| UI         | `shared/ui/input/`        | InputDirective      |
+| Components | `components/input-field/` | InputFieldComponent |
+
+### Storybook の利点
+
+| 利点           | 説明                                   |
+| -------------- | -------------------------------------- |
+| 独立開発       | コンポーネントを単体でテスト可能       |
+| ドキュメント   | 自動生成されるドキュメント             |
+| ビジュアルテスト| UI の変更を視覚的に確認               |
+| チーム共有     | デザイナーとの連携がスムーズ           |
+
+## まとめ
+
+shadcn/ui スタイルの UI 構成により、以下を実現できます。
+
+1. **CVA によるバリアント管理** - 型安全で柔軟なスタイリング
+2. **Primitives と Composed の分離** - 再利用性と保守性の向上
+3. **Angular CDK との統合** - アクセシビリティの向上
+4. **Storybook によるカタログ** - UI コンポーネントのドキュメント化
+
+次のページでは、RxAngular と SSR/ISR について解説します。
+
+

--- a/apps/content/articles/06-angular-ngxs/05-rxangular-ssr.md
+++ b/apps/content/articles/06-angular-ngxs/05-rxangular-ssr.md
@@ -1,0 +1,320 @@
+---
+title: RxAngular + SSR/ISR
+description: RxAngularによる高性能リアクティブ処理と、Angular SSR + ISR（Incremental Static Regeneration）の設定方法を解説します。
+---
+
+## RxAngular とは
+
+**RxAngular** は、Angular 向けの高性能リアクティブユーティリティライブラリです。特に Zoneless 環境での Observable 処理に優れています。
+
+### パッケージ構成
+
+| パッケージ              | 用途                             |
+| ----------------------- | -------------------------------- |
+| `@rx-angular/template`  | テンプレートディレクティブ       |
+| `@rx-angular/cdk`       | 低レベルユーティリティ           |
+| `@rx-angular/isr`       | ISR（Incremental Static Regeneration） |
+
+## @rx-angular/template
+
+### *rxLet ディレクティブ
+
+Zoneless 環境で Observable を効率的に描画するためのディレクティブです。
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { RxLet } from '@rx-angular/template/let';
+
+import { HomeFacade } from '$domains/home';
+
+@Component({
+  imports: [RxLet],
+  template: `
+    <div *rxLet="count$; let count">
+      Count: {{ count }}
+    </div>
+  `,
+})
+export class HomeComponent {
+  private readonly facade = inject(HomeFacade);
+  readonly count$ = this.facade.count$;
+}
+```
+
+### async パイプとの比較
+
+| 機能                   | async パイプ | *rxLet        |
+| ---------------------- | ------------ | ------------- |
+| Zoneless 対応          | ❌           | ✅            |
+| 変更検知の効率         | 低い         | **高い**      |
+| サスペンス対応         | ❌           | ✅            |
+| エラーハンドリング     | ❌           | ✅            |
+| コンテキスト変数       | 1つ          | **複数**      |
+
+### サスペンスとエラーハンドリング
+
+```html
+<div *rxLet="data$; let data; suspense: loading; error: errorTpl">
+  {{ data }}
+</div>
+
+<ng-template #loading>
+  <p>Loading...</p>
+</ng-template>
+
+<ng-template #errorTpl let-error>
+  <p>Error: {{ error.message }}</p>
+</ng-template>
+```
+
+### *rxFor ディレクティブ
+
+`*ngFor` の高性能版。大量のリスト描画に最適です。
+
+```typescript
+import { RxFor } from '@rx-angular/template/for';
+
+@Component({
+  imports: [RxFor],
+  template: `
+    <ul>
+      <li *rxFor="let item of items$; trackBy: 'id'">
+        {{ item.name }}
+      </li>
+    </ul>
+  `,
+})
+export class ListComponent {
+  items$ = this.store.select(state => state.items);
+}
+```
+
+## Angular SSR
+
+**Angular SSR** は、サーバーサイドレンダリングを提供します。SEO とパフォーマンスの向上に効果的です。
+
+### プロジェクト構成
+
+```
+src/
+├── app/
+│   ├── app.config.ts          # クライアント設定
+│   ├── app.config.server.ts   # サーバー設定
+│   ├── app.routes.ts          # クライアントルート
+│   └── app.routes.server.ts   # サーバールート
+├── main.ts                    # クライアントエントリー
+├── main.server.ts             # サーバーエントリー
+└── server.ts                  # Express サーバー
+```
+
+### サーバー設定
+
+```typescript
+// app.config.server.ts
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/platform-server';
+import { provideServerRoutesConfig } from '@angular/ssr';
+
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(),
+    provideServerRoutesConfig(serverRoutes),
+  ],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+```
+
+### サーバールート設定
+
+```typescript
+// app.routes.server.ts
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: '',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: 'home',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: '**',
+    renderMode: RenderMode.Server,
+  },
+];
+```
+
+### RenderMode の種類
+
+| モード              | 説明                                   | 用途                   |
+| ------------------- | -------------------------------------- | ---------------------- |
+| `Prerender`         | ビルド時に静的 HTML を生成             | 静的ページ             |
+| `Server`            | リクエスト時にサーバーでレンダリング   | 動的ページ             |
+| `Client`            | クライアントのみでレンダリング         | SPA 動作               |
+
+## ISR（Incremental Static Regeneration）
+
+**ISR** は、静的ページを増分的に再生成する機能です。静的サイトの高速性と動的コンテンツの鮮度を両立できます。
+
+### @rx-angular/isr のセットアップ
+
+```bash
+pnpm add @rx-angular/isr
+```
+
+### サーバー設定
+
+```typescript
+// server.ts
+import { AngularNodeAppEngine, isMainModule, writeResponseToNodeResponse } from '@angular/ssr/node';
+import express from 'express';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ISRHandler } from '@rx-angular/isr/server';
+
+const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+const browserDistFolder = resolve(serverDistFolder, '../browser');
+
+const app = express();
+const angularApp = new AngularNodeAppEngine();
+
+// ISR ハンドラーの設定
+const isr = new ISRHandler({
+  indexHtml: resolve(browserDistFolder, 'index.html'),
+  invalidateSecretToken: process.env['INVALIDATE_TOKEN'] ?? 'secret',
+  enableLogging: true,
+});
+
+// 静的ファイルの配信
+app.use(
+  express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: false,
+    redirect: false,
+  }),
+);
+
+// ISR ルートの処理
+app.get('*', async (req, res, next) => {
+  const { html, status } = await isr.render(req, res, next);
+  if (html) {
+    res.status(status).send(html);
+  }
+});
+
+// サーバー起動
+if (isMainModule(import.meta.url)) {
+  const port = process.env['PORT'] ?? 4000;
+  app.listen(port, () => {
+    console.log(`Server listening on http://localhost:${port}`);
+  });
+}
+
+export default app;
+```
+
+### ルートごとの revalidate 設定
+
+```typescript
+// app.routes.ts
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./home/home').then(m => m.HomeComponent),
+    data: { revalidate: 60 },  // 60秒ごとに再生成
+  },
+  {
+    path: 'about',
+    loadComponent: () => import('./about/about').then(m => m.AboutComponent),
+    data: { revalidate: 3600 },  // 1時間ごとに再生成
+  },
+];
+```
+
+### ISR の動作フロー
+
+```
+1. 初回リクエスト → サーバーでレンダリング → キャッシュに保存
+2. 2回目以降 → キャッシュから配信（高速）
+3. revalidate 時間経過後 → バックグラウンドで再生成
+4. 次のリクエスト → 新しいキャッシュを配信
+```
+
+### キャッシュの手動無効化
+
+```bash
+# API エンドポイントで無効化
+curl -X POST "http://localhost:4000/api/invalidate?secret=your-secret&path=/home"
+```
+
+## Hydration
+
+**Hydration** は、サーバーで生成された HTML にクライアントの JavaScript をアタッチする処理です。
+
+### Event Replay
+
+Angular 19 以降、Event Replay が導入されました。Hydration 完了前のユーザー操作を記録し、完了後に再生します。
+
+```typescript
+// app.config.ts
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideClientHydration(withEventReplay()),
+  ],
+};
+```
+
+### Hydration の利点
+
+| 利点           | 説明                                         |
+| -------------- | -------------------------------------------- |
+| 高速な初期表示 | サーバーで生成された HTML をすぐ表示         |
+| SEO            | 検索エンジンが HTML をインデックス可能       |
+| Event Replay   | Hydration 中のユーザー操作を逃さない         |
+
+## パフォーマンス最適化
+
+### レンダリング戦略の選択
+
+| ページタイプ     | 推奨戦略          | 理由                           |
+| ---------------- | ----------------- | ------------------------------ |
+| ランディングページ | Prerender + ISR | SEO重要、更新頻度低い          |
+| ブログ記事       | Prerender + ISR   | SEO重要、定期的に更新          |
+| ダッシュボード   | Server            | ユーザー固有データ             |
+| 設定ページ       | Client            | SEO不要、インタラクション重視  |
+
+### SSR 起動コマンド
+
+```bash
+# 開発時
+pnpm --filter @monorepo/client start
+
+# ビルド
+pnpm --filter @monorepo/client build
+
+# SSR サーバー起動
+pnpm --filter @monorepo/client serve:ssr:client
+```
+
+## まとめ
+
+RxAngular と SSR/ISR により、以下を実現できます。
+
+1. **RxAngular** - Zoneless 環境での効率的な Observable 処理
+2. **Angular SSR** - SEO とパフォーマンスの向上
+3. **ISR** - 静的サイトの高速性と動的コンテンツの鮮度の両立
+4. **Event Replay** - Hydration 中のユーザー体験の向上
+
+次のページでは、Vertical Slice Architecture によるアーキテクチャ設計について解説します。
+
+

--- a/apps/content/articles/06-angular-ngxs/06-architecture.md
+++ b/apps/content/articles/06-angular-ngxs/06-architecture.md
@@ -1,0 +1,314 @@
+---
+title: アーキテクチャ設計
+description: Vertical Slice ArchitectureとClean Architectureを組み合わせたフロントエンドアーキテクチャ設計を解説します。
+---
+
+## アーキテクチャ概要
+
+このテンプレートでは、**Vertical Slice Architecture** と **Clean Architecture** を組み合わせた設計を採用しています。
+
+## Vertical Slice Architecture
+
+機能（ドメイン）ごとにコードを垂直に分割し、各スライスが独立して開発・テスト可能な構造です。
+
+### 利点
+
+| 観点               | 説明                                       |
+| ------------------ | ------------------------------------------ |
+| **凝集度が高い**   | 関連するコードが同じディレクトリにまとまる |
+| **変更の影響範囲** | 機能追加・修正が他のドメインに影響しにくい |
+| **スケーラブル**   | チームやマイクロフロントエンドへの分割が容易 |
+| **認知しやすい**   | 機能ごとにファイルが整理され、理解しやすい |
+
+### 従来のレイヤードアーキテクチャとの比較
+
+```
+# レイヤードアーキテクチャ（横分割）
+src/
+├── components/
+│   ├── UserForm.ts
+│   └── ProductList.ts
+├── services/
+│   ├── user.service.ts
+│   └── product.service.ts
+└── stores/
+    ├── user.store.ts
+    └── product.store.ts
+
+# Vertical Slice Architecture（縦分割）
+src/
+├── domains/
+│   ├── user/
+│   │   ├── user.facade.ts
+│   │   └── store/
+│   │       ├── user.state.ts
+│   │       └── user.actions.ts
+│   └── product/
+│       ├── product.facade.ts
+│       └── store/
+│           ├── product.state.ts
+│           └── product.actions.ts
+```
+
+Vertical Slice では、**ユーザー機能を変更するときに `domains/user/` だけを見れば良い**という利点があります。
+
+## ディレクトリ構成
+
+```
+src/
+├── app/              # (a) ルートコンポーネント + 各ページ
+│   ├── app.ts            # ルートコンポーネント
+│   ├── app.config.ts     # アプリケーション設定
+│   ├── app.routes.ts     # ルーティング定義
+│   └── {page}/           # 各ページ（Vertical Slice）
+│       ├── {page}.ts         # ページコンポーネント
+│       └── templates/        # ページ固有のテンプレート
+├── components/       # (c) 複数ページで共有するコンポーネント（Composed UI）
+├── domains/          # (d) ドメインロジック + 状態管理（NGXS）
+├── modules/          # (m) 機能モジュール（ユースケース） ※将来拡張用
+├── shared/           # (s) 共有リソース
+│   ├── lib/              # ユーティリティ関数
+│   └── ui/               # UIプリミティブ（shadcn/ui相当）
+├── main.ts
+└── index.html
+```
+
+## レイヤー構成
+
+| ディレクトリ  | レイヤー              | 責務                                             |
+| ------------- | --------------------- | ------------------------------------------------ |
+| `app/`        | Presentation          | ページ・ルーティング・UI表示                     |
+| `components/` | Presentation (Shared) | 複数ページで共有するUIコンポーネント             |
+| `domains/`    | Domain + Application  | エンティティ・状態管理（NGXS）・ビジネスロジック |
+| `modules/`    | Application           | domains間で共有するユースケース・業務ロジック    |
+| `shared/`     | Infrastructure        | ユーティリティ・UIプリミティブ・アダプター       |
+
+## 依存関係のルール
+
+```
+app/ ──→ components/ ──→ domains/ ──→ modules/ ──→ shared/
+```
+
+- 上位レイヤーは下位レイヤーに依存できる（右方向への依存のみ許可）
+- 下位レイヤーは上位レイヤーに依存してはならない（左方向への依存は禁止）
+- `shared/` は全レイヤーから参照可能
+
+### ESLint による自動検証
+
+`eslint-plugin-boundaries` を使用して、依存関係のルールを自動検証できます。
+
+```javascript
+// eslint.config.mjs
+import boundaries from 'eslint-plugin-boundaries';
+
+export default [
+  {
+    plugins: { boundaries },
+    settings: {
+      'boundaries/elements': [
+        { type: 'app', pattern: 'src/app/*' },
+        { type: 'components', pattern: 'src/components/*' },
+        { type: 'domains', pattern: 'src/domains/*' },
+        { type: 'modules', pattern: 'src/modules/*' },
+        { type: 'shared', pattern: 'src/shared/*' },
+      ],
+    },
+    rules: {
+      'boundaries/element-types': [
+        'error',
+        {
+          default: 'disallow',
+          rules: [
+            { from: 'app', allow: ['components', 'domains', 'modules', 'shared'] },
+            { from: 'components', allow: ['domains', 'modules', 'shared'] },
+            { from: 'domains', allow: ['modules', 'shared'] },
+            { from: 'modules', allow: ['shared'] },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+## 配置基準
+
+### どこに何を置くか
+
+| 対象                        | 配置先                    | 例                                   |
+| --------------------------- | ------------------------- | ------------------------------------ |
+| ルーティング対象のページ    | `app/{page}/`             | `app/home/home.ts`                   |
+| ページ固有のUI部品          | `app/{page}/templates/`   | `app/home/templates/hero-section.ts` |
+| 複数ページで共有するUI      | `components/`             | `components/input-field/`            |
+| Composed UI（ロジック連携） | `components/`             | `components/input-field/`            |
+| 状態管理（NGXS State）      | `domains/{domain}/store/` | `domains/home/store/home.state.ts`   |
+| Facade                      | `domains/{domain}/`       | `domains/home/home.facade.ts`        |
+| ビジネスロジック            | `domains/{domain}/`       | `domains/user/user.service.ts`       |
+| domains間共有ロジック       | `modules/`                | `modules/auth/auth.guard.ts`         |
+| UIプリミティブ（最小単位）  | `shared/ui/`              | `shared/ui/button/button.ts`         |
+| ユーティリティ関数          | `shared/lib/`             | `shared/lib/utils.ts`                |
+
+## パスエイリアス
+
+パスエイリアスを使用して、インポートを簡潔にします。
+
+```typescript
+// tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "$app/*": ["src/app/*"],
+      "$components/*": ["src/components/*"],
+      "$domains/*": ["src/domains/*"],
+      "$modules/*": ["src/modules/*"],
+      "$shared/*": ["src/shared/*"]
+    }
+  }
+}
+```
+
+### 使用例
+
+```typescript
+import { ButtonDirective } from '$shared/ui';
+import { cn } from '$shared/lib';
+import { HomeFacade } from '$domains/home';
+import { InputFieldComponent } from '$components/input-field';
+```
+
+## 命名規則
+
+| 対象         | 規則                                      | 例                    |
+| ------------ | ----------------------------------------- | --------------------- |
+| コンポーネント| `{name}.ts`（単一ファイルコンポーネント） | `home.ts`             |
+| テンプレート | `{name}.html`（必要な場合のみ分離）       | `home.html`           |
+| スタイル     | `{name}.css`（必要な場合のみ分離）        | `home.css`            |
+| テスト       | `{name}.spec.ts` または `{name}.test.ts`  | `home.spec.ts`        |
+| State        | `{domain}.state.ts`                       | `home.state.ts`       |
+| Actions      | `{domain}.actions.ts`                     | `home.actions.ts`     |
+| Facade       | `{domain}.facade.ts`                      | `home.facade.ts`      |
+
+## 新しいドメインの追加方法
+
+新しいドメイン（例: `user`）を追加する場合の手順です。
+
+### 1. ディレクトリ構造を作成
+
+```
+src/domains/user/
+├── store/
+│   ├── user.state.ts
+│   └── user.actions.ts
+├── user.facade.ts
+└── index.ts
+```
+
+### 2. State を定義
+
+```typescript
+// domains/user/store/user.state.ts
+import { Injectable } from '@angular/core';
+import { Action, Selector, State, StateContext } from '@ngxs/store';
+
+import { LoadUser } from './user.actions';
+
+export interface UserStateModel {
+  user: User | null;
+  loading: boolean;
+}
+
+@State<UserStateModel>({
+  name: 'user',
+  defaults: {
+    user: null,
+    loading: false,
+  },
+})
+@Injectable()
+export class UserState {
+  @Selector()
+  static getUser(state: UserStateModel): User | null {
+    return state.user;
+  }
+
+  @Selector()
+  static isLoading(state: UserStateModel): boolean {
+    return state.loading;
+  }
+
+  @Action(LoadUser)
+  loadUser(ctx: StateContext<UserStateModel>, action: LoadUser): void {
+    ctx.patchState({ loading: true });
+    // API 呼び出しなど
+  }
+}
+```
+
+### 3. Facade を作成
+
+```typescript
+// domains/user/user.facade.ts
+import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngxs/store';
+
+import { LoadUser } from './store/user.actions';
+import { UserState } from './store/user.state';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserFacade {
+  private readonly store = inject(Store);
+
+  readonly user$ = this.store.select(UserState.getUser);
+  readonly loading$ = this.store.select(UserState.isLoading);
+
+  loadUser(id: string): void {
+    this.store.dispatch(new LoadUser(id));
+  }
+}
+```
+
+### 4. エクスポートを設定
+
+```typescript
+// domains/user/index.ts
+export * from './store/user.state';
+export * from './store/user.actions';
+export * from './user.facade';
+
+// domains/index.ts
+import { HomeState } from './home/store/home.state';
+import { UserState } from './user/store/user.state';
+
+export const APP_STATES = [HomeState, UserState];
+export * from './home';
+export * from './user';
+```
+
+## 設計思想
+
+### なぜこの構成か
+
+1. **アルファベット順の一貫性**: `app → components → domains → modules → shared` の順で視覚的に整理
+2. **Vertical Slice**: 各ページが独立したスライスとして完結し、凝集度が高い
+3. **DDD境界の意識**: ページ固有のものはページ内に、共有するものだけが上位レイヤーに昇格
+4. **shadcn/uiアプローチ**: `shared/ui/` にUIプリミティブを配置し、コピー＆カスタマイズ可能な構成
+5. **Facade パターン**: Store へのアクセスを抽象化し、コンポーネントとの結合度を下げる
+
+### Angular公式スタイルガイドとの差異
+
+本構成はAngular公式スタイルガイドの推奨（機能ごとのディレクトリ構成）とは一部異なります。これは設計原則（Clean Architecture / Vertical Slice）を優先した意図的な選択です。
+
+## まとめ
+
+Vertical Slice Architecture により、以下を実現できます。
+
+1. **高い凝集度** - 関連するコードが同じ場所にまとまる
+2. **低い結合度** - ドメイン間の依存を最小限に
+3. **スケーラビリティ** - チーム分割やマイクロフロントエンド化に対応
+4. **保守性** - 変更の影響範囲が限定的
+
+このアーキテクチャ設計により、プロジェクトが成長しても保守しやすいコードベースを維持できます。
+
+


### PR DESCRIPTION
## 概要

Angular 21 + NGXS モダンフロントエンド開発ガイドの記事シリーズを追加します。

テンプレートリポジトリ: https://github.com/motora-dev/angular-ngxs

## 追加した記事（6ページ）

| ファイル | タイトル | 内容 |
|---------|---------|------|
| `01-overview.md` | 概要 | テンプレートの特徴、対象読者、プロジェクト構成 |
| `02-zoneless-angular.md` | Angular 21 Zoneless 変更検知 | `provideZonelessChangeDetection()`、Signal、変更検知の仕組み |
| `03-ngxs-facade.md` | NGXS 状態管理 + Facade パターン | State/Action/Selector定義、Facadeによる抽象化、@ngxs/form-plugin連携 |
| `04-ui-storybook.md` | shadcn/ui スタイル UI + Storybook | CVA + Angular CDK、Primitives vs Composed、cn()ユーティリティ、Storybook |
| `05-rxangular-ssr.md` | RxAngular + SSR/ISR | @rx-angular/template、`*rxLet`、ISR設定 |
| `06-architecture.md` | アーキテクチャ設計 | Vertical Slice Architecture、ディレクトリ構成、依存関係ルール |

## 変更内容

- `apps/content/articles/06-angular-ngxs/` ディレクトリを新規作成
- 関連記事（04, 05）の概要ページを更新